### PR TITLE
add zip_get_version  and zip_get_version_id functions 

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -161,6 +161,7 @@ SET(LIBZIP_SOURCES
   zip_unchange_archive.c
   zip_unchange_data.c
   zip_utf-8.c
+  zip_version.c
 )
 
 IF(WIN32)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -136,7 +136,8 @@ libzip_la_SOURCES=\
 	zip_unchange_all.c \
 	zip_unchange_archive.c \
 	zip_unchange_data.c \
-	zip_utf-8.c
+	zip_utf-8.c \
+	zip_version.c
 
 BUILT_SOURCES=zipconf.h
 CLEANFILES=	${BUILT_SOURCES}

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -429,6 +429,7 @@ ZIP_EXTERN int zip_unchange_all(zip_t *);
 ZIP_EXTERN int zip_unchange_archive(zip_t *);
 ZIP_EXTERN const char *zip_get_version(void);
 ZIP_EXTERN int zip_get_version_id(int what);
+#define LIBZIP_VERSION_ID (LIBZIP_VERSION_MAJOR << 16 | LIBZIP_VERSION_MINOR << 8 | LIBZIP_VERSION_MICRO)
 #define zip_get_version_major() zip_get_version_id(1)
 #define zip_get_version_minor() zip_get_version_id(2)
 #define zip_get_version_micro() zip_get_version_id(3)

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -427,6 +427,11 @@ ZIP_EXTERN const char *zip_strerror(zip_t *);
 ZIP_EXTERN int zip_unchange(zip_t *, zip_uint64_t);
 ZIP_EXTERN int zip_unchange_all(zip_t *);
 ZIP_EXTERN int zip_unchange_archive(zip_t *);
+ZIP_EXTERN const char *zip_get_version(void);
+ZIP_EXTERN int zip_get_version_id(int what);
+#define zip_get_version_major() zip_get_version_id(1)
+#define zip_get_version_minor() zip_get_version_id(2)
+#define zip_get_version_micro() zip_get_version_id(3)
 
 #ifdef __cplusplus
 }

--- a/lib/zip_version.c
+++ b/lib/zip_version.c
@@ -49,5 +49,5 @@ zip_get_version_id(int what)
         case 2: return LIBZIP_VERSION_MINOR;
         case 3: return LIBZIP_VERSION_MICRO;
     }
-    return LIBZIP_VERSION_MAJOR << 16 | LIBZIP_VERSION_MINOR << 8 | LIBZIP_VERSION_MICRO;
+    return LIBZIP_VERSION_ID;
 }

--- a/lib/zip_version.c
+++ b/lib/zip_version.c
@@ -1,0 +1,53 @@
+/*
+  zip_version.c -- libzip version retrieval
+  Copyright (C) 2011-2014 Dieter Baron and Thomas Klausner
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+  The authors can be contacted at <libzip@nih.at>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+  3. The names of the authors may not be used to endorse or promote
+     products derived from this software without specific prior
+     written permission.
+ 
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "zip.h"
+
+
+ZIP_EXTERN const char *
+zip_get_version(void)
+{
+    return LIBZIP_VERSION;
+}
+
+
+ZIP_EXTERN int
+zip_get_version_id(int what)
+{
+    switch(what) {
+        case 1: return LIBZIP_VERSION_MAJOR;
+        case 2: return LIBZIP_VERSION_MINOR;
+        case 3: return LIBZIP_VERSION_MICRO;
+    }
+    return LIBZIP_VERSION_MAJOR << 16 | LIBZIP_VERSION_MINOR << 8 | LIBZIP_VERSION_MICRO;
+}

--- a/regress/Makefile.am
+++ b/regress/Makefile.am
@@ -7,7 +7,8 @@ noinst_PROGRAMS= \
 	fopen_unchanged \
 	fread \
 	fseek \
-	tryopen
+	tryopen \
+	version
 
 if !WIN32_HOST
 pkglib_LTLIBRARIES=	malloc.la nonrandomopen.la

--- a/regress/version.c
+++ b/regress/version.c
@@ -44,7 +44,13 @@
 int
 main(int argc, char *argv[])
 {
-	printf("Version: %s, %d.%d.%d (0x%x)\n", 
+	printf("Buildtime version: %s, %d.%d.%d (0x%x)\n",
+		LIBZIP_VERSION,
+		LIBZIP_VERSION_MAJOR,
+		LIBZIP_VERSION_MINOR,
+		LIBZIP_VERSION_MICRO,
+		LIBZIP_VERSION_ID);
+	printf("Runtime Version:   %s, %d.%d.%d (0x%x)\n",
 		zip_get_version(),
 		zip_get_version_major(),
 		zip_get_version_minor(),
@@ -55,6 +61,7 @@ main(int argc, char *argv[])
 	if (zip_get_version_minor() != LIBZIP_VERSION_MINOR) return 2;
 	if (zip_get_version_micro() != LIBZIP_VERSION_MICRO) return 3;
 	if (strcmp(zip_get_version(), LIBZIP_VERSION)) return 4;
+	if (zip_get_version_id(0) != LIBZIP_VERSION_ID) return 5;
 
     return 0;
 }

--- a/regress/version.c
+++ b/regress/version.c
@@ -1,0 +1,60 @@
+/*
+  version.c -- tool to check libzip version
+  Copyright (C) 1999-2014 Dieter Baron and Thomas Klausner
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+  The authors can be contacted at <libzip@nih.at>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+  3. The names of the authors may not be used to endorse or promote
+     products derived from this software without specific prior
+     written permission.
+ 
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "compat.h"
+#include "zip.h"
+
+
+int
+main(int argc, char *argv[])
+{
+	printf("Version: %s, %d.%d.%d (0x%x)\n", 
+		zip_get_version(),
+		zip_get_version_major(),
+		zip_get_version_minor(),
+		zip_get_version_micro(),
+		zip_get_version_id(0));
+
+	if (zip_get_version_major() != LIBZIP_VERSION_MAJOR) return 1;
+	if (zip_get_version_minor() != LIBZIP_VERSION_MINOR) return 2;
+	if (zip_get_version_micro() != LIBZIP_VERSION_MICRO) return 3;
+	if (strcmp(zip_get_version(), LIBZIP_VERSION)) return 4;
+
+    return 0;
+}


### PR DESCRIPTION
to retrieve runtime version (which may differ from buildtime version when ABI is compatible)