### PR TITLE
Fixes windows compilation under VS2012

### DIFF
--- a/regress/fseek.c
+++ b/regress/fseek.c
@@ -33,6 +33,7 @@
 
 #include <stdlib.h>
 
+#include "compat.h"
 #include "zip.h"
 
 const char *prg;

--- a/src/ziptool.c
+++ b/src/ziptool.c
@@ -43,6 +43,7 @@
 #ifdef _WIN32
 /* WIN32 needs <fcntl.h> for _O_BINARY */
 #include <fcntl.h>
+#define STDIN_FILENO _fileno(stdin)
 #endif
 
 #ifndef HAVE_GETOPT


### PR DESCRIPTION
Hello,

Here are two minor changes I did in my [libzippp](https://github.com/ctabin/libzippp) patch in order to fully compile libzip with VS2012 under my Windows 7.

Regards,
Cédric