### PR TITLE
pkg-config: Use Libs.private for link dependencies

### DIFF
--- a/libzip.pc.in
+++ b/libzip.pc.in
@@ -9,6 +9,7 @@ zipcmp=@bindir@/zipcmp
 Name: libzip
 Description: library for handling zip archives
 Version: @VERSION@
-Libs: @PKG_CONFIG_RPATH@ -L${libdir} -lzip @LIBS@
+Libs: @PKG_CONFIG_RPATH@ -L${libdir} -lzip
+Libs.private: @LIBS@
 Cflags: -I${includedir}
 


### PR DESCRIPTION
Fixes #38