### PR TITLE
Fix syntax errors in man pages

### DIFF
--- a/man/zip_libzip_version.man
+++ b/man/zip_libzip_version.man
@@ -18,7 +18,7 @@ libzip (-lzip)
 .SH "DESCRIPTION"
 \fBzip_libzip_version\fR
 returns the version number of the library as string in the format
-\(Lq$MAJOR.$MINOR.$MICRO$SUFFIX\(Rq
+\(lq$MAJOR.$MINOR.$MICRO$SUFFIX\(rq
 where
 \fI$MAJOR\fR
 is the major version,

--- a/man/ziptool.man
+++ b/man/ziptool.man
@@ -325,9 +325,9 @@ Add a file called
 to the zip archive
 \fItestbuffer.zip\fR
 with data
-\(LqThis is a test.\en\(Rq
+\(lqThis is a test.\en\(rq
 where
-\(Lq\en\(Rq
+\(lq\en\(rq
 is replaced with a newline character:
 .nf
 .sp


### PR DESCRIPTION
As picked up by lintian and quotes were not rendered in man pages

```
W: libzip-dev: manpage-has-errors-from-man usr/share/man/man3/zip_libzip_version.3.gz 21: warning: can't find special character `Lq'
W: ziptool: manpage-has-errors-from-man usr/share/man/man1/ziptool.1.gz 328: warning: can't find special character `Lq'
```