### PR TITLE
Silence compiler warnings

### DIFF
--- a/regress/nonrandomopentest.c
+++ b/regress/nonrandomopentest.c
@@ -42,7 +42,7 @@ main(int argc, const char *argv[]) {
     int i;
 
 #ifdef HAVE_CRYPTO
-    if (!zip_random(buf, sizeof(buf))) {
+    if (!zip_random((zip_uint8_t*)buf, sizeof(buf))) {
 	fprintf(stderr, "zip_random returned false\n");
 	exit(1);
     }


### PR DESCRIPTION
Getting compiler warning on macOS:
```c
.../libzip/regress/nonrandomopentest.c:45:21: warning: passing 'char [1024]' 
 to parameter of type 'zip_uint8_t *' (aka 'unsigned char *') converts
 between pointers to integer types with different sign [-Wpointer-sign]
    if (!zip_random(buf, sizeof(buf))) {
                    ^~~
.../libzip/regress/../lib/zipint.h:514:41: note: passing argument
 to parameter 'buffer' here
ZIP_EXTERN bool zip_random(zip_uint8_t *buffer, zip_uint16_t length);
                                        ^
1 warning generated.
```
```
$ clang -v
Apple LLVM version 9.1.0 (clang-902.0.39.1)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: .../Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```