### PR TITLE
adding customization for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ OPTION(ENABLE_GNUTLS "Enable use of GnuTLS" ON)
 OPTION(ENABLE_OPENSSL "Enable use of OpenSSL" ON)
 OPTION(ENABLE_COMMONCRYPTO "Enable use of CommonCrypto" ON)
 
+OPTION(BUILD_TOOLS "Build tools in the src directory (zipcmp, zipmerge, ziptool)" ON)
+OPTION(BUILD_REGRESS "Build regression tests" ON)
+OPTION(BUILD_EXAMPLES "Build examples" ON)
+OPTION(BUILD_DOC "Build documentation" ON)
+
 INCLUDE(CheckFunctionExists)
 INCLUDE(CheckIncludeFiles)
 INCLUDE(CheckSymbolExists)
@@ -234,10 +239,23 @@ ENABLE_TESTING()
 
 # Targets
 ADD_SUBDIRECTORY(lib)
+
+IF(BUILD_DOC)
 ADD_SUBDIRECTORY(man)
+ENDIF()
+
+IF(BUILD_TOOLS)
 ADD_SUBDIRECTORY(src)
+ENDIF()
+
+IF(BUILD_REGRESS)
 ADD_SUBDIRECTORY(regress)
+ENDIF()
+
+IF(BUILD_EXAMPLES)
 ADD_SUBDIRECTORY(examples)
+ENDIF()
+
 
 # pkgconfig file
 SET(prefix ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
This patch adds 4 options to allow custom build of libzip.

```
OPTION(BUILD_TOOLS "Build tools in the src directory (zipcmp, zipmerge, ziptool)" ON)
OPTION(BUILD_REGRESS "Build regression tests" ON)
OPTION(BUILD_EXAMPLES "Build examples" ON)
OPTION(BUILD_DOC "Build documentation" ON)
```

This allow easier integration in projects when all is not needed (or would be impossible to build ex: android NDK).
