### PR TITLE
doc: typo: ZIP_SOURCE_STAT_* -> ZIP_STAT_*

### DIFF
--- a/man/zip_source_stat.mdoc
+++ b/man/zip_source_stat.mdoc
@@ -79,24 +79,24 @@ field of the structure specifies which other fields are valid.
 Check if the flag defined by the following defines are in
 .Ar valid
 before accessing the fields:
-.Bl -tag -width ZIP_SOURCE_STAT_ENCRYPTION_METHODXX -compact -offset indent
-.It Dv ZIP_SOURCE_STAT_NAME
+.Bl -tag -width ZIP_STAT_ENCRYPTION_METHODXX -compact -offset indent
+.It Dv ZIP_STAT_NAME
 .Ar name
-.It Dv ZIP_SOURCE_STAT_INDEX
+.It Dv ZIP_STAT_INDEX
 .Ar index
-.It Dv ZIP_SOURCE_STAT_SIZE
+.It Dv ZIP_STAT_SIZE
 .Ar size
-.It Dv ZIP_SOURCE_STAT_COMP_SIZE
+.It Dv ZIP_STAT_COMP_SIZE
 .Ar comp_size
-.It Dv ZIP_SOURCE_STAT_MTIME
+.It Dv ZIP_STAT_MTIME
 .Ar mtime
-.It Dv ZIP_SOURCE_STAT_CRC
+.It Dv ZIP_STAT_CRC
 .Ar crc
-.It Dv ZIP_SOURCE_STAT_COMP_METHOD
+.It Dv ZIP_STAT_COMP_METHOD
 .Ar comp_method
-.It Dv ZIP_SOURCE_STAT_ENCRYPTION_METHOD
+.It Dv ZIP_STAT_ENCRYPTION_METHOD
 .Ar encryption_method
-.It Dv ZIP_SOURCE_STAT_FLAGS
+.It Dv ZIP_STAT_FLAGS
 .Ar flags
 .El
 .Pp


### PR DESCRIPTION
That, or point to the zip_stat page directly :)