### PR TITLE
Let zip.h be in a non system include directory

### DIFF
--- a/lib/zip.h
+++ b/lib/zip.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 #endif
 
-#include <zipconf.h>
+#include "zipconf.h"
 
 #ifndef ZIP_EXTERN
 #ifndef ZIP_STATIC


### PR DESCRIPTION
I'm using libzip in my project but for clarity, I moved include files to a dedicated libzip folder so I could do #include <libzip/zip.h>. Unfortunately, it fails because of <> style inclusion hence my patch.

If you find it useful, please merge.
Thanks.