### PR TITLE
make zip_compression_method_supported public

### DIFF
--- a/cmake-zipconf.h.in
+++ b/cmake-zipconf.h.in
@@ -20,6 +20,7 @@ ${ZIP_NULLABLE_DEFINES}
 ${LIBZIP_TYPES_INCLUDE}
 
 typedef ${ZIP_INT8_T} zip_int8_t;
+typedef ${ZIP_INT8_T} zip_bool_t;
 typedef ${ZIP_UINT8_T} zip_uint8_t;
 typedef ${ZIP_INT16_T} zip_int16_t;
 typedef ${ZIP_UINT16_T} zip_uint16_t;

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -449,6 +449,7 @@ ZIP_EXTERN int zip_unchange(zip_t * _Nonnull, zip_uint64_t);
 ZIP_EXTERN int zip_unchange_all(zip_t * _Nonnull);
 ZIP_EXTERN int zip_unchange_archive(zip_t * _Nonnull);
 ZIP_EXTERN zip_bool_t zip_compression_method_supported(zip_int32_t method, zip_bool_t compress);
+ZIP_EXTERN zip_bool_t zip_encryption_method_supported(zip_uint16_t method, zip_bool_t encode);
 
 #ifdef __cplusplus
 }

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -448,6 +448,7 @@ ZIP_EXTERN const char * _Nonnull zip_strerror(zip_t * _Nonnull);
 ZIP_EXTERN int zip_unchange(zip_t * _Nonnull, zip_uint64_t);
 ZIP_EXTERN int zip_unchange_all(zip_t * _Nonnull);
 ZIP_EXTERN int zip_unchange_archive(zip_t * _Nonnull);
+ZIP_EXTERN zip_bool_t zip_compression_method_supported(zip_int32_t method, zip_bool_t compress);
 
 #ifdef __cplusplus
 }

--- a/lib/zip_get_encryption_implementation.c
+++ b/lib/zip_get_encryption_implementation.c
@@ -55,5 +55,8 @@ _zip_get_encryption_implementation(zip_uint16_t em, int operation) {
 
 ZIP_EXTERN zip_bool_t
 zip_encryption_method_supported(zip_uint16_t method, zip_bool_t encode) {
+    if (method == ZIP_EM_NONE) {
+        return true;
+    }
     return _zip_get_encryption_implementation(method, encode ? ZIP_CODEC_ENCODE : ZIP_CODEC_DECODE) != NULL;
 }

--- a/lib/zip_get_encryption_implementation.c
+++ b/lib/zip_get_encryption_implementation.c
@@ -52,3 +52,8 @@ _zip_get_encryption_implementation(zip_uint16_t em, int operation) {
         return NULL;
     }
 }
+
+ZIP_EXTERN zip_bool_t
+zip_encryption_method_supported(zip_uint16_t method, zip_bool_t encode) {
+    return _zip_get_encryption_implementation(method, encode ? ZIP_CODEC_ENCODE : ZIP_CODEC_DECODE) != NULL;
+}

--- a/lib/zip_source_compress.c
+++ b/lib/zip_source_compress.c
@@ -106,8 +106,8 @@ get_algorithm(zip_int32_t method, bool compress) {
     return NULL;
 }
 
-bool
-zip_compression_method_supported(zip_int32_t method, bool compress) {
+ZIP_EXTERN zip_bool_t
+zip_compression_method_supported(zip_int32_t method, zip_bool_t compress) {
     if (method == ZIP_CM_STORE) {
 	return true;
     }

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -155,8 +155,6 @@ extern zip_compression_algorithm_t zip_algorithm_xz_compress;
 extern zip_compression_algorithm_t zip_algorithm_xz_decompress;
 
 
-bool zip_compression_method_supported(zip_int32_t method, bool compress);
-
 /* This API is not final yet, but we need it internally, so it's private for now. */
 
 const zip_uint8_t *zip_get_extra_field_by_id(zip_t *, int, int, zip_uint16_t, int, zip_uint16_t *);

--- a/src/ziptool.c
+++ b/src/ziptool.c
@@ -828,17 +828,26 @@ usage(const char *progname, const char *reason) {
 		 "\tu\tZIP_FL_UNCHANGED\n");
     fprintf(out, "\nSupported compression methods are:\n"
 		 "\tdefault\n"
-#if defined(HAVE_LIBBZ2)
-		 "\tbzip2\n"
-#endif
 		 "\tdeflate\n"
 		 "\tstore\n");
-    fprintf(out, "\nSupported compression methods are:\n"
+	if (zip_compression_method_supported(ZIP_CM_BZIP2, 1)) {
+		fprintf(out, "\tbzip2\n");
+	}
+	if (zip_compression_method_supported(ZIP_CM_XZ, 1)) {
+		fprintf(out, "\txz\n");
+	}
+	fprintf(out, "\nSupported encryption methods are:\n"
 		 "\tnone\n"
-		 "\tTRAD-PKWARE\n"
-		 "\tAES-128\n"
-		 "\tAES-192\n"
-		 "\tAES-256\n");
+		 "\tTRAD-PKWARE\n");
+	if (zip_encryption_method_supported(ZIP_EM_AES_128, 1)) {
+		fprintf(out, "\tAES-128\n");
+	}
+	if (zip_encryption_method_supported(ZIP_EM_AES_192, 1)) {
+		fprintf(out, "\tAES-192\n");
+	}
+	if (zip_encryption_method_supported(ZIP_EM_AES_256, 1)) {
+		fprintf(out, "\tAES-256\n");
+	}
     fprintf(out, "\nThe index is zero-based.\n");
     exit(0);
 }


### PR DESCRIPTION
Nice to have to avoid having to use `zip_set_file_compression` and managed `ZIP_ER_COMPNOTSUPP` errors


P.S. I introduce zip_bool_t to avoid having to change compatibility layer to include <stdbool.h> everywhere