### PR TITLE
CIFuzz integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libzip'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libzip'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
[CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) will run the fuzz target (`zip_read_fuzzer.c`) each time a pull request is submitted to detect bugs before they make it into the codebase.

It runs for about 10 minutes and produces a test case if it finds a bug, the bug can be reproduced with [fuzz_main](https://github.com/nih-at/libzip/blob/master/regress/CMakeLists.txt#L221) if the project is built with `-fsanitize=address/undefined` set as CFLAGS.