### PR TITLE
Fix mingw builds

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -164,6 +164,8 @@ SET(LIBZIP_SOURCES
 
 IF(WIN32)
   SET(LIBZIP_OPSYS_FILES
+    zip_mkstempm.c
+    zip_random_win32.c
     zip_source_win32handle.c
     zip_source_win32utf8.c
     zip_source_win32w.c

--- a/lib/zip_random_win32.c
+++ b/lib/zip_random_win32.c
@@ -72,9 +72,9 @@ zip_random_uint32(void) {
     }
     
     if (!seeded) {
-        srandom((unsigned int)time(NULL));
+        srand((unsigned int)time(NULL));
     }
     
-    return (zip_uint32_t)random();
+    return (zip_uint32_t)rand();
 }
 #endif


### PR DESCRIPTION
1. `srandom` and `random` are POSIX extensions not present on non-POSIX
   platforms, replace them with `srand` and `rand` respectively. They
   _might_ produce different results, but that shouldn't matter in the
   context of the caller, which is the non-secure version
2. Add sources providing mkstemp function to libzip libraries