### PR TITLE
Ensure all calls `fopen` use "rb" mode

### DIFF
--- a/examples/in-memory.c
+++ b/examples/in-memory.c
@@ -45,7 +45,7 @@ get_data(void **datap, size_t *sizep, const char *archive) {
     struct stat st;
     FILE *fp;
 
-    if ((fp = fopen(archive, "r")) == NULL) {
+    if ((fp = fopen(archive, "rb")) == NULL) {
 	if (errno != ENOENT) {
 	    fprintf(stderr, "can't open %s: %s\n", archive, strerror(errno));
 	    return -1;

--- a/regress/add_from_filep.c
+++ b/regress/add_from_filep.c
@@ -69,7 +69,7 @@ main(int argc, char *argv[]) {
 	return 1;
     }
 
-    if ((fp = fopen(file, "r")) == NULL) {
+    if ((fp = fopen(file, "rb")) == NULL) {
 	fprintf(stderr, "%s: can't open input file '%s': %s\n", prg, file, strerror(errno));
 	return 1;
     }

--- a/regress/ziptool_regress.c
+++ b/regress/ziptool_regress.c
@@ -151,7 +151,7 @@ read_to_memory(const char *archive, int flags, zip_error_t *error, zip_source_t 
 	return NULL;
     }
 
-    if ((fp = fopen(archive, "r")) == NULL) {
+    if ((fp = fopen(archive, "rb")) == NULL) {
 	if (errno == ENOENT) {
 	    src = zip_source_buffer_create(NULL, 0, 0, error);
 	}

--- a/src/zipcmp.c
+++ b/src/zipcmp.c
@@ -273,7 +273,7 @@ compute_crc(const char *fname) {
     Bytef buffer[8192];
 
 
-    if ((f = fopen(fname, "r")) == NULL) {
+    if ((f = fopen(fname, "rb")) == NULL) {
 	fprintf(stderr, "%s: can't open %s: %s\n", progname, fname, strerror(errno));
 	return -1;
     }


### PR DESCRIPTION
Some commercial systems have wrong notion about opening files in
non-binary mode, pre-emptively open all the files as binary.