### PR TITLE
Add missing NULL check in zip_stat_index.

### DIFF
--- a/lib/zip_stat_index.c
+++ b/lib/zip_stat_index.c
@@ -55,7 +55,7 @@ zip_stat_index(zip_t *za, zip_uint64_t index, zip_flags_t flags, zip_stat_t *st)
             return -1;
         }
 
-        if (entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
+        if (entry->changes != NULL && entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
             st->mtime = de->last_mod;
             st->valid |= ZIP_STAT_MTIME;
         }


### PR DESCRIPTION
This was found on a project we have running on Windows. We would get a native crash when opening and updating an entry from a stream. We found that in this case `entry->changes` was `NULL` which was causing the crash. 

Not sure if this is right but adding the `NULL` check works around the problem. It might be enough, if not please let me know what else needs to happen. I'm quite happy to add code to this PR.