### PR TITLE
[Windows] Provide meaningful error message for PATH_NOT_FOUND

### DIFF
--- a/lib/zip_source_file_win32.c
+++ b/lib/zip_source_file_win32.c
@@ -156,6 +156,7 @@ _zip_win32_error_to_errno(DWORD win32err) {
     case ERROR_INVALID_PARAMETER:
         return EINVAL;
     case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
         return ENOENT;
     case ERROR_INVALID_HANDLE:
         return EBADF;


### PR DESCRIPTION
`ENOENT` means no such file or directory, which on Windows is either
`FILE_NOT_FOUND` or `PATH_NOT_FOUND`.  I've noticed the meaningless
"Unknown error" while working on <https://bugs.php.net/80261>, where
the overlong path caused `GetFileAttributesExW()` to fail with
`PATH_NOT_FOUND`.