### PR TITLE
add missing header to have malloc/free available

### DIFF
--- a/lib/zip_source_file_win32.h
+++ b/lib/zip_source_file_win32.h
@@ -43,6 +43,8 @@
 
 #include <aclapi.h>
 
+#include <stdlib.h>
+
 #include "zipint.h"
 
 #include "zip_source_file.h"


### PR DESCRIPTION
Without this (and if not the ZIP_ALLOCATE_BUFFER define is set by chance), you will get on Windows 64-bit (at least if only zlib/zstd ist compiled in):

D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_utf16.c(81): warning C4013: 'malloc' undefined; assuming extern returning int
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_utf16.c(81): warning C4312: 'type cast': conversion from 'int' to 'char *' of greater size
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_utf8.c(63): warning C4013: 'malloc' undefined; assuming extern returning int
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_utf8.c(63): warning C4312: 'type cast': conversion from 'int' to 'wchar_t *' of greater size
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_utf8.c(71): warning C4013: 'free' undefined; assuming extern returning int
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_named.c(143): warning C4013: 'free' undefined; assuming extern returning int
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_ansi.c(78): warning C4013: 'malloc' undefined; assuming extern returning int
D:\makefactory\zip-ZMWGK7ie\zip\src\lib\zip_source_file_win32_ansi.c(78): warning C4312: 'type cast': conversion from 'int' to 'char *' of greater size
