### PR TITLE
Zstd 1.3.6 is enough

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if(ENABLE_LZMA)
 endif(ENABLE_LZMA)
 
 if(ENABLE_ZSTD)
-  find_package(Zstd 1.5)
+  find_package(Zstd 1.3.6)
   if(Zstd_FOUND)
     set(HAVE_LIBZSTD 1)
   else()


### PR DESCRIPTION
In c39f01daa6ce011960e852bfc6147a96769b0955

> ZSTD_minCLevel() and ZSTD_maxCLevel() are from zstd 1.5 

From https://github.com/facebook/zstd/commit/9bb6c15f7966f59d001f782f087484a414eba570
The commit which introduces this function is in 1.3.6

Notice: and, at least, I can confirm libzip 1.8.0 work as expected (build + test suite) on RHEL / CentOS 8 which have 1.4.4
