### PR TITLE
Fix check of _zip_filetime_to_time_t

### DIFF
--- a/lib/zip_source_file_win32.c
+++ b/lib/zip_source_file_win32.c
@@ -184,7 +184,7 @@ _zip_stat_win32(zip_source_file_context_t *ctx, zip_source_file_stat_t *st, HAND
         zip_error_set(&ctx->error, ZIP_ER_READ, _zip_win32_error_to_errno(GetLastError()));
         return false;
     }
-    if (_zip_filetime_to_time_t(mtimeft, &mtime) < 0) {
+    if (!_zip_filetime_to_time_t(mtimeft, &mtime)) {
         zip_error_set(&ctx->error, ZIP_ER_READ, ERANGE);
         return false;
     }


### PR DESCRIPTION
Commit (https://github.com/nih-at/libzip/commit/528ab2d6f37d54ffda58a1785fc593869ecf0656) changed the return values of **_zip_filetime_to_time_t**. The corresponding return value check should be changed too. 