### PR TITLE
zip_mkstempm: Add flag to allow using a custom suffix 

### DIFF
--- a/lib/zip_source_file_stdio_named.c
+++ b/lib/zip_source_file_stdio_named.c
@@ -129,7 +129,7 @@ _zip_stdio_op_create_temp_output(zip_source_file_context_t *ctx) {
     FILE *tfp;
     struct stat st;
 
-    if ((temp = (char *)malloc(strlen(ctx->fname) + 8)) == NULL) {
+    if ((temp = (char *)malloc(strlen(ctx->fname) + 13)) == NULL) {
         zip_error_set(&ctx->error, ZIP_ER_MEMORY, 0);
         return -1;
     }
@@ -141,9 +141,9 @@ _zip_stdio_op_create_temp_output(zip_source_file_context_t *ctx) {
         mode = -1;
     }
 
-    sprintf(temp, "%s.XXXXXX", ctx->fname);
+    sprintf(temp, "%s.XXXXXX.part", ctx->fname);
 
-    if ((tfd = _zip_mkstempm(temp, mode)) == -1) {
+    if ((tfd = _zip_mkstempm(temp, mode, 2)) == -1) {
         zip_error_set(&ctx->error, ZIP_ER_TMPOPEN, errno);
         free(temp);
         return -1;
@@ -182,8 +182,8 @@ _zip_stdio_op_create_temp_output_cloning(zip_source_file_context_t *ctx, zip_uin
 
 #ifdef HAVE_CLONEFILE
 #ifndef __clang_analyzer__
-    /* we can't use mkstemp, since clonefile insists on creating the file */
-    if (mktemp(temp) == NULL) {
+    /* we can't use mkstemp (flag = 0), since clonefile insists on creating the file */
+    if (_zip_mkstempm(temp, -1, 1) == -1) {
         zip_error_set(&ctx->error, ZIP_ER_TMPOPEN, errno);
         free(temp);
         return -1;
@@ -213,7 +213,7 @@ _zip_stdio_op_create_temp_output_cloning(zip_source_file_context_t *ctx, zip_uin
             return -1;
         }
 
-        if ((fd = mkstemp(temp)) < 0) {
+        if ((fd = _zip_mkstempm(temp, -1, 0)) < 0) {
             zip_error_set(&ctx->error, ZIP_ER_TMPOPEN, errno);
             free(temp);
             return -1;

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -576,7 +576,7 @@ zip_hash_t *_zip_hash_new(zip_error_t *error);
 bool _zip_hash_reserve_capacity(zip_hash_t *hash, zip_uint64_t capacity, zip_error_t *error);
 bool _zip_hash_revert(zip_hash_t *hash, zip_error_t *error);
 
-int _zip_mkstempm(char *path, int mode);
+int _zip_mkstempm(char *path, int mode, unsigned int flag);
 
 zip_t *_zip_open(zip_source_t *, unsigned int, zip_error_t *);
 


### PR DESCRIPTION
There could be such a scenario for new users:

1. Compress many files or large files.
2. A temporary file is created.
3. The user doesn't know it's a temporary file, and continuously tries to open it.

The situation has happened in a video: https://youtu.be/TtsglXhbxno?t=720

We should give the temporary file a descriptive suffix, and ".part" seems to be the most reasonable and familiar suffix for most users, because the suffix is also used by many browsers to indicate a file is still being downloaded.

To make the solution clean, `_zip_mkstempm` is also adapted to three use cases:

1. Default mode      (mkstemp)
2. Fill in name only (mktemp)
3. Fill in name only, but with a custom suffix

When calling `_zip_stdio_op_create_temp_output`, the third flag is used so a custom suffix is made possible.