### PR TITLE
Don't hide the temp file

### DIFF
--- a/lib/zip_source_file_stdio_named.c
+++ b/lib/zip_source_file_stdio_named.c
@@ -301,7 +301,7 @@ static int create_temp_file(zip_source_file_context_t *ctx, bool create_file) {
         mode = -1;
     }
     
-    if ((temp = (char *)malloc(strlen(ctx->fname) + 14)) == NULL) {
+    if ((temp = (char *)malloc(strlen(ctx->fname) + 13)) == NULL) {
         zip_error_set(&ctx->error, ZIP_ER_MEMORY, 0);
         return -1;
     }
@@ -313,7 +313,7 @@ static int create_temp_file(zip_source_file_context_t *ctx, bool create_file) {
     else {
         file_name += 1;
     }
-    sprintf(temp, "%.*s.%s.XXXXXX.part", (int)(file_name - ctx->fname), ctx->fname, file_name);
+    sprintf(temp, "%.*s%s.XXXXXX.part", (int)(file_name - ctx->fname), ctx->fname, file_name);
     
     end = temp + strlen(temp) - 5;
     start = end - 6;


### PR DESCRIPTION
According to [the discussion](https://invent.kde.org/teams/usability/issue-board/-/issues/2#note_355542), hiding the temp file can be problematic because:

1. If the compression operation fails for some reason (disk full,
   segfault, etc) the user won't be able to see the file directly
   and is unlikely to delete it.
2. Lack of instantaneous feedback that something is happening.

make check on btrfs: 100% tests passed, 0 tests failed out of 145