### PR TITLE
zip_random_uwp: use BCRYPT_SUCCESS macro

### DIFF
--- a/lib/zip_random_uwp.c
+++ b/lib/zip_random_uwp.c
@@ -39,20 +39,19 @@
 
 #ifndef HAVE_SECURE_RANDOM
 
-#include <bcrypt.h>
-#include <ntstatus.h>
 #include <windows.h>
+#include <bcrypt.h>
 
 ZIP_EXTERN bool
 zip_secure_random(zip_uint8_t *buffer, zip_uint16_t length) {
     BCRYPT_ALG_HANDLE hAlg = NULL;
     NTSTATUS hr = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_RNG_ALGORITHM, MS_PRIMITIVE_PROVIDER, 0);
-    if (hr != STATUS_SUCCESS || hAlg == NULL) {
+    if (!BCRYPT_SUCCESS(hr) || hAlg == NULL) {
         return false;
     }
     hr = BCryptGenRandom(&hAlg, buffer, length, 0);
     BCryptCloseAlgorithmProvider(&hAlg, 0);
-    if (hr != STATUS_SUCCESS) {
+    if (!BCRYPT_SUCCESS(hr)) {
         return false;
     }
     return true;


### PR DESCRIPTION
- Simplify logic using the BCRYPT_SUCCESS macro, included in <bcrypt.h>
- Remove unused include <ntstatus.h>
- Put <windows.h> before <bcrypt.h> to fix compilation issues (some projects like [flycast ](https://github.com/flyinghead/flycast/blob/master/core/deps/libzip/lib/zip_random_uwp.c#L42-L43) or [ppsspp ](https://github.com/hrydgard/ppsspp/blob/d4d6dea443267878de1250b6365391f5502417c8/ext/libzip/zip_random_uwp.c#L43-L44)have done the same in order to build correctly, this change should help them to stay in sync with this repository)