### PR TITLE
Address potential buffer overrun issues

### DIFF
--- a/lib/zip_buffer.c
+++ b/lib/zip_buffer.c
@@ -140,8 +140,11 @@ _zip_buffer_read(zip_buffer_t *buffer, zip_uint8_t *data, zip_uint64_t length) {
 
     copied = 0;
     while (copied < length) {
-        size_t n = ZIP_MIN(length - copied, SIZE_MAX);
-        (void)memcpy_s(data + copied, length - copied, _zip_buffer_get(buffer, n), n);
+        if (length - copied != (size_t)(length - copied)) {
+            return 0;
+        }
+        size_t n = ZIP_MIN((size_t)(length - copied), SIZE_MAX);
+        (void)memcpy_s(data + copied, (size_t)(length - copied), _zip_buffer_get(buffer, n), n);
         copied += n;
     }
 
@@ -155,7 +158,10 @@ _zip_buffer_new(zip_uint8_t *data, zip_uint64_t size) {
     zip_buffer_t *buffer;
 
     if (data == NULL) {
-        if ((data = (zip_uint8_t *)malloc(size)) == NULL) {
+        if (size != (size_t)size) {
+            return NULL;
+        }
+        if ((data = (zip_uint8_t *)malloc((size_t)size)) == NULL) {
             return NULL;
         }
     }

--- a/lib/zip_dir_add.c
+++ b/lib/zip_dir_add.c
@@ -65,7 +65,11 @@ zip_dir_add(zip_t *za, const char *name, zip_flags_t flags) {
             zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
             return -1;
         }
+#if __STDC_WANT_SECURE_LIB__
+        strcpy_s(s, len + 2, name);
+#else
         strcpy(s, name);
+#endif
         s[len] = '/';
         s[len + 1] = '\0';
     }

--- a/lib/zip_dirent.c
+++ b/lib/zip_dirent.c
@@ -1089,13 +1089,20 @@ _zip_get_dirent(zip_t *za, zip_uint64_t idx, zip_flags_t flags, zip_error_t *err
 
 void
 _zip_u2d_time(time_t intime, zip_uint16_t *dtime, zip_uint16_t *ddate) {
-    struct tm *tpm;
+    struct tm *tpm = NULL;
 
 #ifdef HAVE_LOCALTIME_R
     struct tm tm;
     tpm = localtime_r(&intime, &tm);
 #else
+#if __STDC_WANT_SECURE_LIB__
+    struct tm tm;
+    errno_t err = localtime_s(&tm, &intime);
+    if (err == 0)
+      tpm = &tm;
+#else
     tpm = localtime(&intime);
+#endif // __STDC_WANT_SECURE_LIB__
 #endif
     if (tpm == NULL) {
         /* if localtime() fails, return an arbitrary date (1980-01-01 00:00:00) */

--- a/lib/zip_error_to_str.c
+++ b/lib/zip_error_to_str.c
@@ -50,8 +50,9 @@ zip_error_to_str(char *buf, zip_uint64_t len, int ze, int se) {
     zip_error_set(&error, ze, se);
 
     error_string = zip_error_strerror(&error);
-
-    ret = snprintf_s(buf, len, error_string, strlen(error_string));
+    if (len != (size_t)len)
+      return -1;
+    ret = snprintf_s(buf, (size_t)len, error_string, strlen(error_string));
 
     zip_error_fini(&error);
 

--- a/lib/zip_extra_field.c
+++ b/lib/zip_extra_field.c
@@ -244,10 +244,13 @@ _zip_ef_parse(const zip_uint8_t *data, zip_uint16_t len, zip_flags_t flags, zip_
         /* Android APK files align stored file data with padding in extra fields; ignore. */
         /* see https://android.googlesource.com/platform/build/+/master/tools/zipalign/ZipAlign.cpp */
         /* buffer is at most 64k long, so this can't overflow. */
-        size_t glen = _zip_buffer_left(buffer);
+        zip_uint64_t glen = _zip_buffer_left(buffer);
+        if (glen > SIZE_MAX) {
+            glen = SIZE_MAX;
+        }
         zip_uint8_t *garbage;
         garbage = _zip_buffer_get(buffer, glen);
-        if (glen >= 4 || garbage == NULL || memcmp(garbage, "\0\0\0", glen) != 0) {
+        if (glen >= 4 || garbage == NULL || memcmp(garbage, "\0\0\0", (size_t)glen) != 0) {
             zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_EF_TRAILING_GARBAGE);
             _zip_buffer_free(buffer);
             _zip_ef_free(ef_head);

--- a/lib/zip_fdopen.c
+++ b/lib/zip_fdopen.c
@@ -31,6 +31,7 @@
   IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <tchar.h>
 
 #include "zipint.h"
 #ifdef HAVE_UNISTD_H
@@ -59,7 +60,7 @@ zip_fdopen(int fd_orig, int _flags, int *zep) {
         return NULL;
     }
 
-    if ((fp = fdopen(fd, "rb")) == NULL) {
+    if ((fp = _tfdopen(fd, _T("rb"))) == NULL) {
         close(fd);
         _zip_set_open_error(zep, NULL, ZIP_ER_OPEN);
         return NULL;

--- a/lib/zip_source_buffer.c
+++ b/lib/zip_source_buffer.c
@@ -225,8 +225,10 @@ read_data(void *state, void *data, zip_uint64_t len, zip_source_cmd_t cmd) {
             zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
             return -1;
         }
-
-        (void)memcpy_s(data, len, &ctx->attributes, sizeof(ctx->attributes));
+        if (len != (size_t)len) {
+            return 0;
+        }
+        (void)memcpy_s(data, (size_t)len, &ctx->attributes, sizeof(ctx->attributes));
 
         return sizeof(ctx->attributes);
     }
@@ -538,7 +540,10 @@ buffer_read(buffer_t *buffer, zip_uint8_t *data, zip_uint64_t length) {
     while (n < length) {
         zip_uint64_t left = ZIP_MIN(length - n, buffer->fragments[i].length - fragment_offset);
 
-        (void)memcpy_s(data + n, length - n, buffer->fragments[i].data + fragment_offset, left);
+        if (length - n != (size_t)(length - n) || left != (size_t)left) {
+            return 0;
+        }
+        (void)memcpy_s(data + n, (size_t)(length - n), buffer->fragments[i].data + fragment_offset, (size_t)left);
 
         if (left == buffer->fragments[i].length - fragment_offset) {
             i++;
@@ -614,8 +619,11 @@ buffer_write(buffer_t *buffer, const zip_uint8_t *data, zip_uint64_t length, zip
     copied = 0;
     while (copied < length) {
         zip_uint64_t n = ZIP_MIN(ZIP_MIN(length - copied, buffer->fragments[i].length - fragment_offset), SIZE_MAX);
+        if(buffer->fragments[i].length - fragment_offset != (size_t)(buffer->fragments[i].length - fragment_offset)){
+            return -1;
+        }
 
-        (void)memcpy_s(buffer->fragments[i].data + fragment_offset, buffer->fragments[i].length - fragment_offset, data + copied, (size_t)n);
+        (void)memcpy_s(buffer->fragments[i].data + fragment_offset,(size_t)(buffer->fragments[i].length - fragment_offset), data + copied, (size_t)n);
 
         if (n == buffer->fragments[i].length - fragment_offset) {
             i++;

--- a/lib/zip_source_compress.c
+++ b/lib/zip_source_compress.c
@@ -240,7 +240,10 @@ compress_read(zip_source_t *src, struct context *ctx, void *data, zip_uint64_t l
             if (ctx->can_store && (zip_uint64_t)ctx->first_read <= out_offset) {
                 ctx->is_stored = true;
                 ctx->size = (zip_uint64_t)ctx->first_read;
-                (void)memcpy_s(data, len, ctx->buffer, ctx->size);
+                if (len != (size_t)len || ctx->size != (size_t)(ctx->size)) {
+                    return -1;
+                }
+                (void)memcpy_s(data, (size_t)len, ctx->buffer, (size_t)(ctx->size));
                 return (zip_int64_t)ctx->size;
             }
             end = true;

--- a/lib/zip_source_file_common.c
+++ b/lib/zip_source_file_common.c
@@ -262,7 +262,10 @@ read_file(void *state, void *data, zip_uint64_t len, zip_source_cmd_t cmd) {
             zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
             return -1;
         }
-        (void)memcpy_s(data, len, &ctx->attributes, sizeof(ctx->attributes));
+        if (len != (size_t)len) {
+            return 0;
+        }
+        (void)memcpy_s(data, (size_t)len, &ctx->attributes, sizeof(ctx->attributes));
         return sizeof(ctx->attributes);
 
     case ZIP_SOURCE_OPEN:
@@ -354,8 +357,10 @@ read_file(void *state, void *data, zip_uint64_t len, zip_source_cmd_t cmd) {
             zip_error_set(&ctx->error, zip_error_code_zip(&ctx->stat_error), zip_error_code_system(&ctx->stat_error));
             return -1;
         }
-
-        (void)memcpy_s(data, len, &ctx->st, sizeof(ctx->st));
+        if (len != (size_t)len) {
+            return 0;
+        }
+        (void)memcpy_s(data, (size_t)len, &ctx->st, sizeof(ctx->st));
         return sizeof(ctx->st);
     }
 


### PR DESCRIPTION
Changes:

- Use more secure functions (e.g. *_s functions) for Microsoft CRT implementations that support secure libraries.
- Fixed possible buffer overrun issues by ensuring that allocation’s inputs don’t suffer from integer overflow or truncation (or just add a cast when the target variable cannot be truncated).