### PR TITLE
Better detect correct zlib flag in pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,29 @@ find_package(ZLIB 1.1.2 REQUIRED)
 # can override the name used in the pkg-config file
 if (NOT ZLIB_LINK_LIBRARY_NAME)
   set(ZLIB_LINK_LIBRARY_NAME "z")
+
+  # Get the correct name in common cases
+  list(LENGTH ZLIB_LIBRARIES N_ZLIB_LIBRARIES)
+  if(N_ZLIB_LIBRARIES EQUAL 1)
+    set(ZLIB_FILENAME ${ZLIB_LIBRARIES})
+  elseif(N_ZLIB_LIBRARIES EQUAL 4)
+    # ZLIB_LIBRARIES might have the target_link_library() format like
+    # "optimized;path/to/zlib.lib;debug;path/to/zlibd.lib". Use the 'optimized'
+    # case unless we know we are in a Debug build.
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      list(FIND ZLIB_LIBRARIES "debug" ZLIB_LIBRARIES_INDEX_OF_CONFIG)
+    else()
+      list(FIND ZLIB_LIBRARIES "optimized" ZLIB_LIBRARIES_INDEX_OF_CONFIG)
+    endif()
+    if(ZLIB_LIBRARIES_INDEX_OF_CONFIG GREATER_EQUAL 0)
+      math(EXPR ZLIB_FILENAME_INDEX "${ZLIB_LIBRARIES_INDEX_OF_CONFIG}+1")
+      list(GET ZLIB_LIBRARIES ${ZLIB_FILENAME_INDEX} ZLIB_FILENAME)
+    endif()
+  endif()
+  if(ZLIB_FILENAME)
+    get_filename_component(ZLIB_FILENAME ${ZLIB_FILENAME} NAME_WE)
+    string(REGEX REPLACE "^lib" "" ZLIB_LINK_LIBRARY_NAME ${ZLIB_FILENAME})
+  endif()
 endif(NOT ZLIB_LINK_LIBRARY_NAME)
 
 if(ENABLE_BZIP2)


### PR DESCRIPTION
This is for #311.

On Windows, zlib is usually named `zlib.lib` or `zlibd.lib`. Make `libzip.pc` contain the correct `-l` flag for this case.

On Unix platforms, `ZLIB_LIBRARIES` is usually something like `/path/to/libz.so` (or `.a`), which still results in `-lz` after this change.

When the CMake generator is Visual Studio (build type not known at config time), the result may not be correct for Debug builds. (This can only be fixed by generating the `.pc` at build type rather than configuration time.)

Tested on:
Windows, vcpkg zlib:x64-windows-static, Ninja, Debug (-> -lzlibd)
Windows, vcpkg zlib:x64-windows-static, Ninja, Release (-> -lzlib)
Windows, vcpkg zlib:x64-windows-static, Ninja, RelWithDebInfo (-> -lzlib)
Windows, vcpkg zlib:x64-windows-static, Visual Studio (-> -lzlib)
Windows, ZLIB_LIBRARY zlibd.lib & ZLIB_INCLUDE_DIR, Ninja, Debug (-> -lzlibd)
Windows, ZLIB_LIBRARY zlib.lib & ZLIB_INCLUDE_DIR, Ninja, Release (-> -lzlib)
Windows, ZLIB_LIBRARY zlib.lib & ZLIB_INCLUDE_DIR, Visual Studio (-> -lzlib)
Ubuntu, system zlib (no cmake flags), Ninja, no build type (-> -lz)
Ubuntu, system zlib (no cmake flags), Ninja, Debug (-> -lz)
Ubuntu, system zlib (no cmake flags), Ninja, Release (-> -lz)
macOS, macOS SDK zlib (no cmake flags), Ninja, no build type (-> -lz)
macOS, macOS SDK zlib (no cmake flags), Ninja, Debug (-> -lz)
macOS, macOS SDK zlib (no cmake flags), Ninja, Release (-> -lz)