### PR TITLE
Support mbedtls3 discovery

### DIFF
--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -85,7 +85,14 @@ find_library(MbedTLS_LIBRARY
 
 # Extract version information from the header file
 if(MbedTLS_INCLUDE_DIR)
-  if(EXISTS ${MbedTLS_INCLUDE_DIR}/mbedtls/version.h)
+  if(EXISTS ${MbedTLS_INCLUDE_DIR}/mbedtls/build_info.h)
+    file(STRINGS ${MbedTLS_INCLUDE_DIR}/mbedtls/build_info.h _ver_line
+        REGEX "^#define MBEDTLS_VERSION_STRING  *\"[0-9]+\\.[0-9]+\\.[0-9]+\""
+        LIMIT_COUNT 1)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+"
+        MbedTLS_VERSION "${_ver_line}")
+    unset(_ver_line)
+  elseif(EXISTS ${MbedTLS_INCLUDE_DIR}/mbedtls/version.h)
     file(STRINGS ${MbedTLS_INCLUDE_DIR}/mbedtls/version.h _ver_line
          REGEX "^#define MBEDTLS_VERSION_STRING  *\"[0-9]+\\.[0-9]+\\.[0-9]+\""
          LIMIT_COUNT 1)


### PR DESCRIPTION
MbedTLS moved version string to `build_info.h`. MbedTLS 3 API wise should maintain compatibility - at least I did not notice any issue.