### PR TITLE
Replace usage of sprintf with snprintf

### DIFF
--- a/lib/zip_error_strerror.c
+++ b/lib/zip_error_strerror.c
@@ -108,7 +108,7 @@ zip_error_strerror(zip_error_t *err) {
             return _zip_err_str[ZIP_ER_MEMORY].description;
         }
 
-        sprintf(s, "%s%s%s", (zip_error_string ? zip_error_string : ""), (zip_error_string ? ": " : ""), system_error_string);
+        snprintf(s, length + 1, "%s%s%s", (zip_error_string ? zip_error_string : ""), (zip_error_string ? ": " : ""), system_error_string);
         err->str = s;
 
         return s;

--- a/lib/zip_source_file_stdio_named.c
+++ b/lib/zip_source_file_stdio_named.c
@@ -300,11 +300,12 @@ static int create_temp_file(zip_source_file_context_t *ctx, bool create_file) {
         mode = -1;
     }
     
-    if ((temp = (char *)malloc(strlen(ctx->fname) + 13)) == NULL) {
+    size_t temp_size = strlen(ctx->fname) + 13;
+    if ((temp = (char *)malloc(temp_size)) == NULL) {
         zip_error_set(&ctx->error, ZIP_ER_MEMORY, 0);
         return -1;
     }
-    sprintf(temp, "%s.XXXXXX.part", ctx->fname);
+    snprintf(temp, temp_size, "%s.XXXXXX", ctx->fname);
     end = temp + strlen(temp) - 5;
     start = end - 6;
     

--- a/regress/liboverride-test.c
+++ b/regress/liboverride-test.c
@@ -66,14 +66,15 @@ main(int argc, const char *argv[]) {
     
     if (getenv("LIBOVERRIDE_SET") == NULL) {
         char *cwd = getcwd(NULL, 0);
-        char *so = (char *)malloc(strlen(cwd) + 64);
+        size_t so_size = strlen(cwd) + 64;
+        char *so = (char *)malloc(so_size);
         if (so == NULL) {
             if (verbose) {
                 printf("malloc failed\n");
             }
             exit(2);
         }
-        sprintf(so, "%s/libliboverride.so", cwd);
+        snprintf(so, so_size, "%s/libliboverride.so", cwd);
         setenv("LIBOVERRIDE_SET", "1", 1);
         setenv("LD_PRELOAD", so, 1);
         execv(argv[0], (void *)argv);

--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -87,10 +87,10 @@ void diff_output_data(diff_output_t *output, int side, const zip_uint8_t *data, 
         hexdata[offset++] = (i == 0 ? '<' : ' ');
 
         if (i >= MAX_BYTES) {
-            sprintf(hexdata + offset, "...");
+            snprintf(hexdata + offset, sizeof(hexdata) - offset, "...");
             break;
         }
-        sprintf(hexdata + offset, "%02x", data[i]);
+        snprintf(hexdata + offset, sizeof(hexdata) - offset, "%02x", data[i]);
         offset += 2;
     }
 

--- a/src/zipcmp.c
+++ b/src/zipcmp.c
@@ -487,12 +487,13 @@ list_directory(const char *name, struct archive *a) {
                         break;
                     }
                     
-                    dir_name = malloc(strlen(ent->fts_path + prefix_length) + 2);
+                    size_t dir_name_size = strlen(ent->fts_path + prefix_length) + 2;
+                    dir_name = malloc(dir_name_size);
                     if (dir_name == NULL) {
                         fprintf(stderr, "%s: malloc failure\n", progname);
                         exit(1);
                     }
-                    sprintf(dir_name, "%s/", ent->fts_path + prefix_length);
+                    snprintf(dir_name, dir_name_size, "%s/", ent->fts_path + prefix_length);
                     a->entry[a->nentry].name = dir_name;
                     a->entry[a->nentry].size = 0;
                     a->entry[a->nentry].crc = 0;


### PR DESCRIPTION
Notably, sprintf is deprecated when building agains the iOS16 or macOS13 SDKs