### PR TITLE
Clear up warnings when using clang-cl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
-          vcpkgGitCommitId: 8bb3f9e4a08a5b71ee93a6f1bcdd7a258bb48392
+          vcpkgGitCommitId: f93ba152d55e1d243160e690bc302ffe8638358e
           vcpkgTriplet: x64-windows
           vcpkgArguments: zlib bzip2 liblzma zstd
       - name: prepare build directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,17 @@ on: [push]
 jobs:
   all:
     runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}${{ matrix.name_extra }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-#        os: [macos-latest, ubuntu-latest]
+        cmake_extra: [""]
+        name_extra: [""]
+        include:
+          - os: windows-latest
+            cmake_extra: "-T ClangCl"
+            name_extra: " clang-cl"
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -31,12 +37,12 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake ${{github.workspace}}
+          cmake ${{ matrix.cmake_extra }} ${{github.workspace}}
       - name: configure (Windows)
         if: ${{ runner.os == 'Windows' }}
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake -DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake ${{github.workspace}}
+          cmake ${{ matrix.cmake_extra }} -DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake ${{github.workspace}}
       - name: build
         working-directory: ${{runner.workspace}}/build
         run: |

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -460,12 +460,12 @@ ZIP_EXTERN int zip_source_stat(zip_source_t *_Nonnull, zip_stat_t *_Nonnull);
 ZIP_EXTERN zip_int64_t zip_source_tell(zip_source_t *_Nonnull);
 ZIP_EXTERN zip_int64_t zip_source_tell_write(zip_source_t *_Nonnull);
 #ifdef _WIN32
-ZIP_EXTERN zip_source_t *zip_source_win32a(zip_t *, const char *, zip_uint64_t, zip_int64_t);
-ZIP_EXTERN zip_source_t *zip_source_win32a_create(const char *, zip_uint64_t, zip_int64_t, zip_error_t *);
-ZIP_EXTERN zip_source_t *zip_source_win32handle(zip_t *, void *, zip_uint64_t, zip_int64_t);
-ZIP_EXTERN zip_source_t *zip_source_win32handle_create(void *, zip_uint64_t, zip_int64_t, zip_error_t *);
-ZIP_EXTERN zip_source_t *zip_source_win32w(zip_t *, const wchar_t *, zip_uint64_t, zip_int64_t);
-ZIP_EXTERN zip_source_t *zip_source_win32w_create(const wchar_t *, zip_uint64_t, zip_int64_t, zip_error_t *);
+ZIP_EXTERN zip_source_t *_Nullable zip_source_win32a(zip_t *_Nullable, const char *_Nullable, zip_uint64_t, zip_int64_t);
+ZIP_EXTERN zip_source_t *_Nullable zip_source_win32a_create(const char *_Nullable, zip_uint64_t, zip_int64_t, zip_error_t *_Nullable);
+ZIP_EXTERN zip_source_t *_Nullable zip_source_win32handle(zip_t *_Nullable, void *_Nullable, zip_uint64_t, zip_int64_t);
+ZIP_EXTERN zip_source_t *_Nullable zip_source_win32handle_create(void *_Nullable, zip_uint64_t, zip_int64_t, zip_error_t *_Nullable);
+ZIP_EXTERN zip_source_t *_Nullable zip_source_win32w(zip_t *_Nullable, const wchar_t *_Nullable, zip_uint64_t, zip_int64_t);
+ZIP_EXTERN zip_source_t *_Nullable zip_source_win32w_create(const wchar_t *_Nullable, zip_uint64_t, zip_int64_t, zip_error_t *_Nullable);
 #endif
 ZIP_EXTERN zip_source_t *_Nullable zip_source_window_create(zip_source_t *_Nonnull, zip_uint64_t, zip_int64_t, zip_error_t *_Nullable);
 ZIP_EXTERN zip_int64_t zip_source_write(zip_source_t *_Nonnull, const void *_Nullable, zip_uint64_t);

--- a/lib/zip_source_file_win32.h
+++ b/lib/zip_source_file_win32.h
@@ -73,4 +73,12 @@ zip_int64_t _zip_win32_op_tell(zip_source_file_context_t *ctx, void *f);
 bool _zip_filetime_to_time_t(FILETIME ft, time_t *t);
 int _zip_win32_error_to_errno(DWORD win32err);
 
+#ifdef __clang__
+#define DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wincompatible-function-pointer-types\"")
+#define DONT_WARN_INCOMPATIBLE_FN_PTR_END _Pragma("GCC diagnostic pop")
+#else
+#define DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
+#define DONT_WARN_INCOMPATIBLE_FN_PTR_END
+#endif
+
 #endif /* _HAD_ZIP_SOURCE_FILE_WIN32_H */

--- a/lib/zip_source_file_win32_ansi.c
+++ b/lib/zip_source_file_win32_ansi.c
@@ -37,6 +37,7 @@ static char *ansi_allocate_tempname(const char *name, size_t extra_chars, size_t
 static void ansi_make_tempname(char *buf, size_t len, const char *name, zip_uint32_t i);
 
 /* clang-format off */
+DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
 
 zip_win32_file_operations_t ops_ansi = {
     ansi_allocate_tempname,
@@ -50,6 +51,7 @@ zip_win32_file_operations_t ops_ansi = {
     strdup
 };
 
+DONT_WARN_INCOMPATIBLE_FN_PTR_END
 /* clang-format on */
 
 ZIP_EXTERN zip_source_t *

--- a/lib/zip_source_file_win32_named.c
+++ b/lib/zip_source_file_win32_named.c
@@ -99,7 +99,6 @@ _zip_win32_named_op_create_temp_output(zip_source_file_context_t *ctx) {
 
     zip_uint32_t value, i;
     HANDLE th = INVALID_HANDLE_VALUE;
-    void *temp = NULL;
     PSECURITY_DESCRIPTOR psd = NULL;
     PSECURITY_ATTRIBUTES psa = NULL;
     SECURITY_ATTRIBUTES sa;

--- a/lib/zip_source_file_win32_utf16.c
+++ b/lib/zip_source_file_win32_utf16.c
@@ -39,6 +39,7 @@ static void utf16_make_tempname(char *buf, size_t len, const char *name, zip_uin
 static char *utf16_strdup(const char *string);
 
 /* clang-format off */
+DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
 
 zip_win32_file_operations_t ops_utf16 = {
     utf16_allocate_tempname,
@@ -52,6 +53,7 @@ zip_win32_file_operations_t ops_utf16 = {
     utf16_strdup
 };
 
+DONT_WARN_INCOMPATIBLE_FN_PTR_END
 /* clang-format on */
 
 ZIP_EXTERN zip_source_t *


### PR DESCRIPTION
Clears up a bunch of warnings from building with clang-cl

Also adds a clang-cl build to GitHub Actions

I cleared the warnings for casting `something(*)(char*,...)` and `something(*)(wchar_t*,...)` functions to `something(*)(void*,...)` by disabling the warning.  Alternatives include explicitly doing casts or adding wrapper functions that take `void*`.  Preferences?