### PR TITLE
Fix documentation for zip_source_callback

### DIFF
--- a/man/zip_source_function.html
+++ b/man/zip_source_function.html
@@ -99,8 +99,9 @@ The functions <code class="Fn">zip_source_function</code>() and
       <code class="Dv">ZIP_SOURCE_OPEN</code>,
       <code class="Dv">ZIP_SOURCE_READ</code>,
       <code class="Dv">ZIP_SOURCE_CLOSE</code>,
-      <code class="Dv">ZIP_SOURCE_STAT</code>, and
-      <code class="Dv">ZIP_SOURCE_ERROR</code>.</dd>
+      <code class="Dv">ZIP_SOURCE_STAT</code>,
+      <code class="Dv">ZIP_SOURCE_ERROR</code>, and
+      <code class="Dv">ZIP_SOURCE_FREE</code>.</dd>
   <dt>seekable read source</dt>
   <dd>Same as previous, but from a source allowing reading from arbitrary
       offsets (also for read-only zip archive). Must additionally support

--- a/man/zip_source_function.man
+++ b/man/zip_source_function.man
@@ -97,8 +97,9 @@ Must support
 \fRZIP_SOURCE_READ\fR,
 \fRZIP_SOURCE_CLOSE\fR,
 \fRZIP_SOURCE_STAT\fR,
+\fRZIP_SOURCE_ERROR\fR,
 and
-\fRZIP_SOURCE_ERROR\fR.
+\fRZIP_SOURCE_FREE\fR.
 .TP 24n
 seekable read source
 Same as previous, but from a source allowing reading from arbitrary

--- a/man/zip_source_function.mdoc
+++ b/man/zip_source_function.mdoc
@@ -88,8 +88,9 @@ Must support
 .Dv ZIP_SOURCE_READ ,
 .Dv ZIP_SOURCE_CLOSE ,
 .Dv ZIP_SOURCE_STAT ,
+.Dv ZIP_SOURCE_ERROR ,
 and
-.Dv ZIP_SOURCE_ERROR .
+.Dv ZIP_SOURCE_FREE .
 .It seekable read source
 Same as previous, but from a source allowing reading from arbitrary
 offsets (also for read-only zip archive).


### PR DESCRIPTION
Add ZIP_SOURCE_FREE to the list of commands a read only source has to support