### PR TITLE
Drop unused member.

### DIFF
--- a/lib/zip_fopen_index_encrypted.c
+++ b/lib/zip_fopen_index_encrypted.c
@@ -78,7 +78,6 @@ _zip_file_new(zip_t *za) {
         return NULL;
     }
 
-    zf->za = za;
     zip_error_init(&zf->error);
     zf->src = NULL;
 

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -303,7 +303,6 @@ struct zip {
 /* file in zip archive, part of API */
 
 struct zip_file {
-    zip_t *za;         /* zip archive containing this file */
     zip_error_t error; /* error information */
     zip_source_t *src; /* data source */
 };


### PR DESCRIPTION
Looking into the source/reference split and noticed an unused member.