### PR TITLE
Factor our realloc handling to a separate function

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(zip
   zip_open.c
   zip_pkware.c
   zip_progress.c
+  zip_realloc.c
   zip_rename.c
   zip_replace.c
   zip_set_archive_comment.c

--- a/lib/zip_dirent.c
+++ b/lib/zip_dirent.c
@@ -86,32 +86,21 @@ _zip_cdir_new(zip_uint64_t nentry, zip_error_t *error) {
 
 bool
 _zip_cdir_grow(zip_cdir_t *cd, zip_uint64_t additional_entries, zip_error_t *error) {
-    zip_uint64_t i, new_alloc;
-    zip_entry_t *new_entry;
+    zip_uint64_t i;
 
     if (additional_entries == 0) {
         return true;
     }
 
-    new_alloc = cd->nentry_alloc + additional_entries;
-
-    if (new_alloc < additional_entries || new_alloc > SIZE_MAX / sizeof(*(cd->entry))) {
-        zip_error_set(error, ZIP_ER_MEMORY, 0);
+    if (!zip_realloc(&cd->entry, &cd->nentry_alloc, sizeof(*(cd->entry)), additional_entries, error)) {
         return false;
     }
 
-    if ((new_entry = (zip_entry_t *)realloc(cd->entry, sizeof(*(cd->entry)) * (size_t)new_alloc)) == NULL) {
-        zip_error_set(error, ZIP_ER_MEMORY, 0);
-        return false;
-    }
-
-    cd->entry = new_entry;
-
-    for (i = cd->nentry; i < new_alloc; i++) {
+    for (i = cd->nentry; i < cd->nentry_alloc; i++) {
         _zip_entry_init(cd->entry + i);
     }
 
-    cd->nentry = cd->nentry_alloc = new_alloc;
+    cd->nentry = cd->nentry_alloc;
 
     return true;
 }

--- a/lib/zip_realloc.c
+++ b/lib/zip_realloc.c
@@ -1,6 +1,6 @@
 /*
-  zip_add_entry.c -- create and init struct zip_entry
-  Copyright (C) 1999-2021 Dieter Baron and Thomas Klausner
+  zip_realloc.c -- reallocate with additional elements
+  Copyright (C) 2009-2022 Dieter Baron and Thomas Klausner
 
   This file is part of libzip, a library to manipulate ZIP archives.
   The authors can be contacted at <info@libzip.org>
@@ -31,36 +31,45 @@
   IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
 #include <stdlib.h>
 
 #include "zipint.h"
 
+bool zip_realloc_implementation(void **inout_memory, zip_uint64_t *inout_alloced, zip_uint64_t element_size, zip_uint64_t additional_elements, zip_error_t *error) {
+    void *old_memory = *inout_memory;
+    zip_uint64_t old_alloced = *inout_alloced;
+    zip_uint64_t new_alloced;
+    size_t new_size;
+    void *new_memory;
 
-/* NOTE: Signed due to -1 on error.  See zip_add.c for more details. */
-
-zip_int64_t
-_zip_add_entry(zip_t *za) {
-    zip_uint64_t idx;
-
-    if (za->nentry + 1 >= za->nentry_alloc) {
-        zip_uint64_t additional_entries = 2 * za->nentry_alloc;
-
-        if (additional_entries < 16) {
-            additional_entries = 16;
-        }
-        else if (additional_entries > 1024) {
-            additional_entries = 1024;
-        }
-
-        if (!zip_realloc(&za->entry, &za->nentry_alloc, sizeof(struct zip_entry), additional_entries, &za->error)) {
-            return -1;
-        }
+    if (additional_elements == 0) {
+        return true;
     }
 
-    idx = za->nentry++;
+    if (old_alloced + additional_elements < old_alloced) {
+        zip_error_set(error, ZIP_ER_MEMORY, 0);
+        return false;
+    }
 
-    _zip_entry_init(za->entry + idx);
+    new_alloced = old_alloced + additional_elements;
 
-    return (zip_int64_t)idx;
+    if (new_alloced > SIZE_MAX / element_size) {
+        zip_error_set(error, ZIP_ER_MEMORY, 0);
+        return false;
+    }
+
+    /* Cast explicitly to size_t to quiet msvc complaints about
+       possible loss of data. At this point we know that the result of
+       "new_alloced * element_size" should fit into size_t. */
+    new_size = (size_t)(new_alloced * element_size);
+
+    if ((new_memory = realloc(old_memory, new_size)) == NULL) {
+        zip_error_set(error, ZIP_ER_MEMORY, 0);
+        return false;
+    }
+
+    *inout_memory = new_memory;
+    *inout_alloced = new_alloced;
+
+    return true;
 }

--- a/lib/zip_source_window.c
+++ b/lib/zip_source_window.c
@@ -317,18 +317,10 @@ _zip_deregister_source(zip_t *za, zip_source_t *src) {
 
 int
 _zip_register_source(zip_t *za, zip_source_t *src) {
-    zip_source_t **open_source;
-
     if (za->nopen_source + 1 >= za->nopen_source_alloc) {
-        unsigned int n;
-        n = za->nopen_source_alloc + 10;
-        open_source = (zip_source_t **)realloc(za->open_source, n * sizeof(zip_source_t *));
-        if (open_source == NULL) {
-            zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
+        if (!zip_realloc(&za->open_source, &za->nopen_source_alloc, sizeof(zip_source_t *), 10, &za->error)) {
             return -1;
         }
-        za->nopen_source_alloc = n;
-        za->open_source = open_source;
     }
 
     za->open_source[za->nopen_source++] = src;

--- a/lib/zip_source_window.c
+++ b/lib/zip_source_window.c
@@ -303,7 +303,7 @@ window_read(zip_source_t *src, void *_ctx, void *data, zip_uint64_t len, zip_sou
 
 void
 _zip_deregister_source(zip_t *za, zip_source_t *src) {
-    unsigned int i;
+    zip_uint64_t i;
 
     for (i = 0; i < za->nopen_source; i++) {
         if (za->open_source[i] == src) {

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -486,6 +486,8 @@ typedef struct _zip_pkware_keys zip_pkware_keys_t;
 #endif
 #endif
 
+#define zip_realloc(inout_memory, inout_alloced, element_size, additional_elements, error) zip_realloc_implementation((void **)inout_memory, inout_alloced, element_size, additional_elements, error)
+bool zip_realloc_implementation(void **inout_memory, zip_uint64_t *inout_alloced, zip_uint64_t element_size, zip_uint64_t additional_elements, zip_error_t *error);
 
 zip_int64_t _zip_add_entry(zip_t *);
 

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -291,8 +291,8 @@ struct zip {
     zip_uint64_t nentry_alloc; /* number of entries allocated */
     zip_entry_t *entry;        /* entries */
 
-    unsigned int nopen_source;       /* number of open sources using archive */
-    unsigned int nopen_source_alloc; /* number of sources allocated */
+    zip_uint64_t nopen_source;       /* number of open sources using archive */
+    zip_uint64_t nopen_source_alloc; /* number of sources allocated */
     zip_source_t **open_source;      /* open sources using archive */
 
     zip_hash_t *names; /* hash table for name lookup */


### PR DESCRIPTION
While working on source/reference split, I added another growable array that held the references, which meant another piece of code doing overflow checks and invoking realloc, so I decided to factor that out to a single place. While at it, I changed one size member to use `zip_uint64_t`.

This also contains a small behavior change in one place, please see the comment in the code.