### PR TITLE
Fix windows build

### DIFF
--- a/lib/zip_source_buffer.c
+++ b/lib/zip_source_buffer.c
@@ -618,7 +618,7 @@ buffer_write(buffer_t *buffer, const zip_uint8_t *data, zip_uint64_t length, zip
     while (copied < length) {
         zip_uint64_t n = ZIP_MIN(ZIP_MIN(length - copied, buffer->fragments[i].length - fragment_offset), SIZE_MAX);
 #if ZIP_UINT64_MAX > SIZE_MAX
-        n = ZIP_MIN(n, SIZE_MAX)
+        n = ZIP_MIN(n, SIZE_MAX);
 #endif
 
         (void)memcpy_s(buffer->fragments[i].data + fragment_offset, (size_t)n, data + copied, (size_t)n);


### PR DESCRIPTION
Should fix an error on appveyor:

```
C:\projects\libzip\lib\zip_source_buffer.c(624): error C2064: term does not evaluate to a function taking 337 arguments [C:\projects\libzip\build\lib\zip.vcxproj]
C:\projects\libzip\lib\zip_source_buffer.c(624): error C2143: syntax error: missing ')' before 'type' [C:\projects\libzip\build\lib\zip.vcxproj]
C:\projects\libzip\lib\zip_source_buffer.c(624): error C2059: syntax error: ')' [C:\projects\libzip\build\lib\zip.vcxproj]
```
