### PR TITLE
Resolve optional transitive dependencies in libzip-config.cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,15 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-v
 configure_package_config_file("${PROJECT_NAME}-config.cmake.in" "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libzip)
 
+# Install Find* modules, they are required by libzip-config.cmake to resolve dependencies
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindNettle.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindZstd.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindMbedTLS.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/libzip/modules
+  )  
+
 if(LIBZIP_DO_INSTALL)
   # Add targets to the build-tree export set
   export(TARGETS zip

--- a/libzip-config.cmake.in
+++ b/libzip-config.cmake.in
@@ -1,9 +1,43 @@
 @PACKAGE_INIT@
 
-# only needed for static library, and doesn't work as-is
-#include(CMakeFindDependencyMacro)
-#find_dependency(ZLIB::ZLIB)
-# how to handle the optional dependencies?
+# We need to supply transitive dependencies if this config is for a static library
+set(IS_SHARED @BUILD_SHARED_LIBS@)
+if (NOT IS_SHARED)
+  include(CMakeFindDependencyMacro)
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
+
+  set(ENABLE_BZIP2 @BZIP2_FOUND@)
+  set(ENABLE_LZMA @LIBLZMA_FOUND@)
+  set(ENABLE_ZSTD @ZSTD_FOUND@)
+  set(ENABLE_GNUTLS @GNUTLS_FOUND@)
+  set(ENABLE_MBEDTLS @MBEDTLS_FOUND@)
+  set(ENABLE_OPENSSL @OPENSSL_FOUND@)
+
+  find_dependency(ZLIB 1.1.2)
+  if(ENABLE_BZIP2)
+    find_dependency(BZip2)
+  endif()
+
+  if(ENABLE_LZMA)
+    find_dependency(LibLZMA 5.2)
+  endif()
+
+  if(ENABLE_ZSTD)
+    find_dependency(Zstd 1.3.6)
+  endif()
+
+  if(ENABLE_GNUTLS)
+    find_dependency(Nettle 3.0)
+    find_dependency(GnuTLS)
+  endif()
+  if(ENABLE_MBEDTLS)
+    find_dependency(MbedTLS 1.0)
+  endif()
+  if(ENABLE_OPENSSL)
+    find_dependency(OpenSSL)
+  endif()
+endif()
+
 # Provide all our library targets to users.
 include("${CMAKE_CURRENT_LIST_DIR}/libzip-targets.cmake")
 


### PR DESCRIPTION
This is required when building libzip as a static library.