### PR TITLE
Add MOVEFILE_COPY_ALLOWED Attribute to move_file op

### DIFF
--- a/lib/zip_source_file_win32_named.c
+++ b/lib/zip_source_file_win32_named.c
@@ -85,7 +85,7 @@ _zip_win32_named_op_commit_write(zip_source_file_context_t *ctx) {
         }
     }
 
-    if (!file_ops->move_file(ctx->tmpname, ctx->fname, MOVEFILE_REPLACE_EXISTING)) {
+    if (!file_ops->move_file(ctx->tmpname, ctx->fname, MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED)) {
         zip_error_set(&ctx->error, ZIP_ER_RENAME, _zip_win32_error_to_errno(GetLastError()));
         return -1;
     }


### PR DESCRIPTION

Context https://github.com/xamarin/xamarin-android/issues/6467

In the related issue we hit a problem where the user was trying to create a zip archive on a drive which was different from where the `TEMP` folder was set (in this case `c:`).  Once the archive process is complete `zip_close` would raise the following error.

```
Renaming temporary file failed: Permission denied
```

Looking through the documentation [1] on `movefileex` we can see that  if you want to be able to move a file from one drive to anther  we need to include the `MOVEFILE_COPY_ALLOWED` flag in the call.

> When moving a file, the destination can be on a different file system or volume. If the destination is on another drive, you must set the MOVEFILE_COPY_ALLOWED flag in dwFlags.


[1] https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw