### PR TITLE
Regenerate zip_err_str.c only when needed

### DIFF
--- a/cmake/GenerateZipErrorStrings.cmake
+++ b/cmake/GenerateZipErrorStrings.cmake
@@ -1,0 +1,47 @@
+# create zip_err_str.c from zip.h and zipint.h
+file(READ ${PROJECT_SOURCE_DIR}/lib/zip.h zip_h)
+string(REGEX MATCHALL "#define ZIP_ER_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" zip_h_err ${zip_h})
+file(READ ${PROJECT_SOURCE_DIR}/lib/zipint.h zipint_h)
+string(REGEX MATCHALL "#define ZIP_ER_DETAIL_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" zipint_h_err ${zipint_h})
+set(zip_err_str [=[
+/*
+  This file was generated automatically by CMake
+  from zip.h and zipint.h\; make changes there.
+*/
+
+#include "zipint.h"
+
+#define L ZIP_ET_LIBZIP
+#define N ZIP_ET_NONE
+#define S ZIP_ET_SYS
+#define Z ZIP_ET_ZLIB
+
+#define E ZIP_DETAIL_ET_ENTRY
+#define G ZIP_DETAIL_ET_GLOBAL
+
+const struct _zip_err_info _zip_err_str[] = {
+]=])
+set(zip_err_type)
+foreach(errln ${zip_h_err})
+  string(REGEX MATCH "#define ZIP_ER_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" err_t_tt ${errln})
+  string(REGEX MATCH "([L|N|S|Z]+) ([-0-9a-zA-Z,, ']*)" err_t_tt "${CMAKE_MATCH_3}")
+  string(STRIP "${CMAKE_MATCH_2}" err_t_tt)
+  string(APPEND zip_err_str "    { ${CMAKE_MATCH_1}, \"${err_t_tt}\" },\n")
+endforeach()
+string(APPEND zip_err_str [=[}\;
+
+const int _zip_err_str_count = sizeof(_zip_err_str)/sizeof(_zip_err_str[0])\;
+
+const struct _zip_err_info _zip_err_details[] = {
+]=])
+foreach(errln ${zipint_h_err})
+  string(REGEX MATCH "#define ZIP_ER_DETAIL_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" err_t_tt ${errln})
+  string(REGEX MATCH "([E|G]+) ([-0-9a-zA-Z, ']*)" err_t_tt "${CMAKE_MATCH_3}")
+  string(STRIP "${CMAKE_MATCH_2}" err_t_tt)
+  string(APPEND zip_err_str "    { ${CMAKE_MATCH_1}, \"${err_t_tt}\" },\n")
+endforeach()
+string(APPEND zip_err_str [=[}\;
+
+const int _zip_err_details_count = sizeof(_zip_err_details)/sizeof(_zip_err_details[0])\;
+]=])
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/zip_err_str.c ${zip_err_str})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -193,50 +193,16 @@ if(LIBZIP_DO_INSTALL)
   install(FILES zip.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
-# create zip_err_str.h from zip.h
-file(READ ${PROJECT_SOURCE_DIR}/lib/zip.h zip_h)
-string(REGEX MATCHALL "#define ZIP_ER_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" zip_h_err ${zip_h})
-file(READ ${PROJECT_SOURCE_DIR}/lib/zipint.h zipint_h)
-string(REGEX MATCHALL "#define ZIP_ER_DETAIL_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" zipint_h_err ${zipint_h})
-set(zip_err_str [=[
-/*
-  This file was generated automatically by CMake
-  from zip.h and zipint.h\; make changes there.
-*/
-
-#include "zipint.h"
-
-#define L ZIP_ET_LIBZIP
-#define N ZIP_ET_NONE
-#define S ZIP_ET_SYS
-#define Z ZIP_ET_ZLIB
-
-#define E ZIP_DETAIL_ET_ENTRY
-#define G ZIP_DETAIL_ET_GLOBAL
-
-const struct _zip_err_info _zip_err_str[] = {
-]=])
-set(zip_err_type)
-foreach(errln ${zip_h_err})
-  string(REGEX MATCH "#define ZIP_ER_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" err_t_tt ${errln})
-  string(REGEX MATCH "([L|N|S|Z]+) ([-0-9a-zA-Z,, ']*)" err_t_tt "${CMAKE_MATCH_3}")
-  string(STRIP "${CMAKE_MATCH_2}" err_t_tt)
-  string(APPEND zip_err_str "    { ${CMAKE_MATCH_1}, \"${err_t_tt}\" },\n")
-endforeach()
-string(APPEND zip_err_str [=[}\;
-
-const int _zip_err_str_count = sizeof(_zip_err_str)/sizeof(_zip_err_str[0])\;
-
-const struct _zip_err_info _zip_err_details[] = {
-]=])
-foreach(errln ${zipint_h_err})
-  string(REGEX MATCH "#define ZIP_ER_DETAIL_([A-Z0-9_]+) ([0-9]+)[ \t]+/([-*0-9a-zA-Z, ']*)/" err_t_tt ${errln})
-  string(REGEX MATCH "([E|G]+) ([-0-9a-zA-Z, ']*)" err_t_tt "${CMAKE_MATCH_3}")
-  string(STRIP "${CMAKE_MATCH_2}" err_t_tt)
-  string(APPEND zip_err_str "    { ${CMAKE_MATCH_1}, \"${err_t_tt}\" },\n")
-endforeach()
-string(APPEND zip_err_str [=[}\;
-
-const int _zip_err_details_count = sizeof(_zip_err_details)/sizeof(_zip_err_details[0])\;
-]=])
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/zip_err_str.c ${zip_err_str})
+# create zip_err_str.c from zip.h and zipint.h
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zip_err_str.c
+  COMMAND "${CMAKE_COMMAND}"
+    "-DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
+    "-DCMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+    "-P" "${PROJECT_SOURCE_DIR}/cmake/GenerateZipErrorStrings.cmake"
+  DEPENDS
+    ${PROJECT_SOURCE_DIR}/cmake/GenerateZipErrorStrings.cmake
+    ${PROJECT_SOURCE_DIR}/lib/zip.h
+    ${PROJECT_SOURCE_DIR}/lib/zipint.h
+  COMMENT "Generating zip_err_str.c"
+)


### PR DESCRIPTION
I'm currently using libzip as a static library in one of my projects by including it as a git submodule and [using the add_subdirectory command in cmake](https://github.com/chaoticgd/wrench/blob/0f0d4e77a6070e8401ba99065ef948260e1eec2d/thirdparty/CMakeLists.txt#L95). Every time I configure the parent project zip_err_str.c is regenerated, meaning libzip and all targets that use libzip and so on have to be relinked. None of the other libraries I'm using seem to do this, which made me suspect this was a problem with libzip's build scripts.

This pull requests modifies the lib/CMakeLists.txt file so that zip_err_str.c is generated at build time instead of configure time and only if necessary. The logic that generates the file has been moved to its own cmake script which is invoked via add_custom_command. The dependency between libzip and this script [is automatically added by cmake](https://cmake.org/cmake/help/latest/prop_sf/GENERATED.html).

This seems a little complicated, so I considered just including the generated code in the repository instead, but I wanted to keep everything as close as possible to how it was working before. Another approach would've been to use preprocessor hacks, but I don't think that allows for generating more macros, so I ruled that out.