### PR TITLE
deprecated function in Mbed-TLS 3.3.0+

### DIFF
--- a/lib/zip_crypto_mbedtls.c
+++ b/lib/zip_crypto_mbedtls.c
@@ -117,6 +117,8 @@ _zip_crypto_pbkdf2(const zip_uint8_t *key, zip_uint64_t key_length, const zip_ui
     mbedtls_md_context_t sha1_ctx;
     bool ok = true;
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED) || MBEDTLS_VERSION_NUMBER < 0x03030000
+
     mbedtls_md_init(&sha1_ctx);
 
     if (mbedtls_md_setup(&sha1_ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), 1) != 0) {
@@ -128,6 +130,13 @@ _zip_crypto_pbkdf2(const zip_uint8_t *key, zip_uint64_t key_length, const zip_ui
     }
 
     mbedtls_md_free(&sha1_ctx);
+
+#else
+
+    ok = mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA1, (const unsigned char *)key, (size_t)key_length, (const unsigned char *)salt, (size_t)salt_length, (unsigned int)iterations, (uint32_t)output_length, (unsigned char *)output) == 0;
+
+#endif // !defined(MBEDTLS_DEPRECATED_REMOVED) || MBEDTLS_VERSION_NUMBER < 0x03030000
+
     return ok;
 }
 


### PR DESCRIPTION
In recent Mbed-TLS versions >= 3.3.0, `mbedtls_pkcs5_pbkdf2_hmac` has been deprecated in favor of `mbedtls_pkcs5_pbkdf2_hmac_ext`:
* [890e78ae664363aace49449eec7e1f0fd5245925](https://github.com/Mbed-TLS/mbedtls/commit/890e78ae664363aace49449eec7e1f0fd5245925)
* [3d0dfb99c93f26539df4a6f43cfddf2f38dffd4f](https://github.com/Mbed-TLS/mbedtls/commit/3d0dfb99c93f26539df4a6f43cfddf2f38dffd4f)

This patch tries to make it seamless.

Cf openvehicles/libzip#1