### PR TITLE
Fix read/write an archive through symbolic link on Windows

### DIFF
--- a/lib/zip_source_file_win32.h
+++ b/lib/zip_source_file_win32.h
@@ -59,6 +59,7 @@ struct zip_win32_file_operations {
     BOOL(__stdcall *move_file)(const void *from, const void *to, DWORD flags);
     BOOL(__stdcall *set_file_attributes)(const void *name, DWORD attributes);
     char *(*string_duplicate)(const char *string);
+    BOOL(__stdcall *copy_file)(const void *from, const void *to, void* progress_routine, void* data, void* cancel, DWORD flags);
 };
 
 typedef struct zip_win32_file_operations zip_win32_file_operations_t;

--- a/lib/zip_source_file_win32_ansi.c
+++ b/lib/zip_source_file_win32_ansi.c
@@ -48,7 +48,8 @@ zip_win32_file_operations_t ops_ansi = {
     ansi_make_tempname,
     MoveFileExA,
     SetFileAttributesA,
-    strdup
+    strdup,
+    CopyFileExA
 };
 
 DONT_WARN_INCOMPATIBLE_FN_PTR_END

--- a/lib/zip_source_file_win32_named.c
+++ b/lib/zip_source_file_win32_named.c
@@ -217,6 +217,7 @@ _zip_win32_named_op_stat(zip_source_file_context_t *ctx, zip_source_file_stat_t 
     if (!GetFileInformationByHandle(h, &file_info)) {
         DWORD error = GetLastError();
         zip_error_set(&ctx->error, ZIP_ER_READ, _zip_win32_error_to_errno(error));
+        CloseHandle(h);
         return false;
     }
 
@@ -231,12 +232,15 @@ _zip_win32_named_op_stat(zip_source_file_context_t *ctx, zip_source_file_stat_t 
 
     if (!_zip_filetime_to_time_t(file_info.ftLastWriteTime, &st->mtime)) {
         zip_error_set(&ctx->error, ZIP_ER_READ, ERANGE);
+        CloseHandle(h);
         return false;
     }
 
     st->size = ((zip_uint64_t)file_info.nFileSizeHigh << 32) | file_info.nFileSizeLow;
 
     /* TODO: fill in ctx->attributes */
+
+    CloseHandle(h);
 
     return true;
 }

--- a/lib/zip_source_file_win32_named.c
+++ b/lib/zip_source_file_win32_named.c
@@ -85,7 +85,12 @@ _zip_win32_named_op_commit_write(zip_source_file_context_t *ctx) {
         }
     }
 
-    if (!file_ops->move_file(ctx->tmpname, ctx->fname, MOVEFILE_REPLACE_EXISTING)) {
+    if (!file_ops->copy_file(ctx->tmpname, ctx->fname, 0, 0, 0, 0)) {
+        zip_error_set(&ctx->error, ZIP_ER_RENAME, _zip_win32_error_to_errno(GetLastError()));
+        return -1;
+    }
+
+    if (!file_ops->delete_file(ctx->tmpname)) {
         zip_error_set(&ctx->error, ZIP_ER_RENAME, _zip_win32_error_to_errno(GetLastError()));
         return -1;
     }

--- a/lib/zip_source_file_win32_utf16.c
+++ b/lib/zip_source_file_win32_utf16.c
@@ -50,7 +50,8 @@ zip_win32_file_operations_t ops_utf16 = {
     utf16_make_tempname,
     MoveFileExW,
     SetFileAttributesW,
-    utf16_strdup
+    utf16_strdup,
+    CopyFileExW
 };
 
 DONT_WARN_INCOMPATIBLE_FN_PTR_END


### PR DESCRIPTION
Fix for #382 

*  Run `CreateFile` followed by `GetFileInformationByHandle` to obtain file attributes, instead of calling `GetFileAttributesEx`.  This way, if the file path points to a symbolic link, the *file attributes of its target* is obtained.
* When writing to a file, run `CopyFileEx` followed by `DeleteFile` (to delete a temp file) instead of `MoveFile`.  This way, if the file path points to a symbolic link, the contents of the source file (temp file) are copied into *the target of the symbolic link*, instead of overwriting the symbolic link itself.
*  Don't mark a file as non-regular file when its file attribute includes `FILE_ATTRIBUTE_REPARSE_POINT`.   This is the case with symbolic link file as well as under different scenarios. One such case is when a file is under the volume where data deduplication is turned on.