### PR TITLE
Define WIN32_LEAN_AND_MEAN to build the zip library on Windows

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(zip
 add_library(libzip::zip ALIAS zip)
 
 if(WIN32)
+  target_compile_definitions(zip PRIVATE WIN32_LEAN_AND_MEAN)
   target_sources(zip PRIVATE
     zip_source_file_win32.c
     zip_source_file_win32_named.c

--- a/lib/zip_crypto_win.c
+++ b/lib/zip_crypto_win.c
@@ -37,9 +37,6 @@
 
 #include "zip_crypto.h"
 
-#define WIN32_LEAN_AND_MEAN
-#define NOCRYPT
-
 #include <windows.h>
 
 #include <bcrypt.h>


### PR DESCRIPTION
There are other files where windows.h is included but WIN32_LEAN_AND_MEAN is not defined. With this PR, WIN32_LEAN_AND_MEAN is defined consistently across the project