### PR TITLE
Reference actions by commit SHA

### DIFF
--- a/.github/workflows/CIFuzz.yml
+++ b/.github/workflows/CIFuzz.yml
@@ -18,7 +18,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
             name_extra: " clang-cl"
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: install python and pip
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: '3.11'
       - name: install dependencies (Linux)
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install libzstd-dev
       - name: install dependencies (Windows)
         if: ${{ runner.os == 'Windows' }}
-        uses: lukka/run-vcpkg@v7
+        uses: lukka/run-vcpkg@55dacfc31e8e18d7db5616e325de5e2124b20d3b # v7.5
         id: runvcpkg
         with:
           vcpkgGitCommitId: f93ba152d55e1d243160e690bc302ffe8638358e
@@ -54,7 +54,7 @@ jobs:
         run: |
           cmake --build . --config Release
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: regress-directory
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@f9a7c6738f28efb36e31d49c53a201a9c5d6a476 # v2.14.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@f9a7c6738f28efb36e31d49c53a201a9c5d6a476 # v2.14.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -71,4 +71,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@f9a7c6738f28efb36e31d49c53a201a9c5d6a476 # v2.14.2


### PR DESCRIPTION
Resolves https://github.com/nih-at/libzip/issues/377

This PR changes GitHub Actions being referenced by tags like `@v1` to `@{commit-SHA}`.
We're not updating `oss-fuzz` since the project architecture does not support referencing by commit SHA.

Also, I noticed the action `lukka/run-vcpkg` is being used in major 7, but already has a major 11, would you like me to try bumping that action?