### PR TITLE
pkg-config: Add Cflags.private field for static linking

### DIFF
--- a/libzip.pc.in
+++ b/libzip.pc.in
@@ -12,3 +12,4 @@ Version: @PROJECT_VERSION@
 Libs: @PKG_CONFIG_RPATH@ -L${libdir} -lzip
 Libs.private: @LIBS@
 Cflags: -I${includedir}
+Cflags.private: -DZIP_STATIC


### PR DESCRIPTION

    This allows for the usage of $(pkgconf --static --cflags libzip) to produce
    the proper CFLAGS for static linking. Relies on pkgconf rather than pkg-config.
