### PR TITLE
Remove ctest unknown argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,4 +62,4 @@ jobs:
       - name: test
         working-directory: ${{runner.workspace}}/build
         run: |
-          ctest --output-on-failure -v -C Release
+          ctest --output-on-failure -C Release


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/manual/ctest.1.html, there is no lowercase `-v` argument.

This should fix the last workflow run which failed with:
> CMake Error: Unknown argument: -v
CMake Error: Run 'ctest --help' for all supported options.