### PR TITLE
Fix multiple initializations from incompatible pointer types

### DIFF
--- a/lib/zip_source_file_win32_ansi.c
+++ b/lib/zip_source_file_win32_ansi.c
@@ -34,20 +34,26 @@
 #include "zip_source_file_win32.h"
 
 static char *ansi_allocate_tempname(const char *name, size_t extra_chars, size_t *lengthp);
+static HANDLE __stdcall ansi_create_file(const void *name, DWORD access, DWORD share_mode, PSECURITY_ATTRIBUTES security_attributes, DWORD creation_disposition, DWORD file_attributes, HANDLE template_file);
+static BOOL __stdcall ansi_delete_file(const void *name);
+static DWORD __stdcall ansi_get_file_attributes(const void *name);
+static BOOL __stdcall ansi_get_file_attributes_ex(const void *name, GET_FILEEX_INFO_LEVELS info_level, void *information);
 static void ansi_make_tempname(char *buf, size_t len, const char *name, zip_uint32_t i);
+static BOOL __stdcall ansi_move_file(const void *from, const void *to, DWORD flags);
+static BOOL __stdcall ansi_set_file_attributes(const void *name, DWORD attributes);
 
 /* clang-format off */
 DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
 
 zip_win32_file_operations_t ops_ansi = {
     ansi_allocate_tempname,
-    CreateFileA,
-    DeleteFileA,
-    GetFileAttributesA,
-    GetFileAttributesExA,
+    ansi_create_file,
+    ansi_delete_file,
+    ansi_get_file_attributes,
+    ansi_get_file_attributes_ex,
     ansi_make_tempname,
-    MoveFileExA,
-    SetFileAttributesA,
+    ansi_move_file,
+    ansi_set_file_attributes,
     strdup
 };
 
@@ -80,8 +86,43 @@ ansi_allocate_tempname(const char *name, size_t extra_chars, size_t *lengthp) {
     return (char *)malloc(*lengthp);
 }
 
+static HANDLE __stdcall
+ansi_create_file(const void *name, DWORD access, DWORD share_mode, PSECURITY_ATTRIBUTES security_attributes, DWORD creation_disposition, DWORD file_attributes, HANDLE template_file)
+{
+    return CreateFileA((const char *)name, access, share_mode, security_attributes, creation_disposition, file_attributes, template_file);
+}
+
+static BOOL __stdcall
+ansi_delete_file(const void *name)
+{
+    return DeleteFileA((const char *)name);
+}
+
+static DWORD __stdcall
+ansi_get_file_attributes(const void *name)
+{
+    return GetFileAttributesA((const char *)name);
+}
+
+static BOOL __stdcall
+ansi_get_file_attributes_ex(const void *name, GET_FILEEX_INFO_LEVELS info_level, void *information)
+{
+    return GetFileAttributesExA((const char *)name, info_level, information);
+}
 
 static void
 ansi_make_tempname(char *buf, size_t len, const char *name, zip_uint32_t i) {
     snprintf_s(buf, len, "%s.%08x", name, i);
+}
+
+static BOOL __stdcall
+ansi_move_file(const void *from, const void *to, DWORD flags)
+{
+    return MoveFileExA((const char *)from, (const char *)to, flags);
+}
+
+static BOOL __stdcall
+ansi_set_file_attributes(const void *name, DWORD attributes)
+{
+    return SetFileAttributesA((const char *)name, attributes);
 }

--- a/lib/zip_source_file_win32_utf16.c
+++ b/lib/zip_source_file_win32_utf16.c
@@ -34,9 +34,15 @@
 #include "zip_source_file_win32.h"
 
 static char *utf16_allocate_tempname(const char *name, size_t extra_chars, size_t *lengthp);
-static HANDLE __stdcall utf16_create_file(const char *name, DWORD access, DWORD share_mode, PSECURITY_ATTRIBUTES security_attributes, DWORD creation_disposition, DWORD file_attributes, HANDLE template_file);
+static HANDLE __stdcall utf16_create_file(const void *name, DWORD access, DWORD share_mode, PSECURITY_ATTRIBUTES security_attributes, DWORD creation_disposition, DWORD file_attributes, HANDLE template_file);
+static BOOL __stdcall utf16_delete_file(const void *name);
+static DWORD __stdcall utf16_get_file_attributes(const void *name);
+static BOOL __stdcall utf16_get_file_attributes_ex(const void *name, GET_FILEEX_INFO_LEVELS info_level, void *information);
 static void utf16_make_tempname(char *buf, size_t len, const char *name, zip_uint32_t i);
+static BOOL __stdcall utf16_move_file(const void *from, const void *to, DWORD flags);
+static BOOL __stdcall utf16_set_file_attributes(const void *name, DWORD attributes);
 static char *utf16_strdup(const char *string);
+
 
 /* clang-format off */
 DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
@@ -44,12 +50,12 @@ DONT_WARN_INCOMPATIBLE_FN_PTR_BEGIN
 zip_win32_file_operations_t ops_utf16 = {
     utf16_allocate_tempname,
     utf16_create_file,
-    DeleteFileW,
-    GetFileAttributesW,
-    GetFileAttributesExW,
+    utf16_delete_file,
+    utf16_get_file_attributes,
+    utf16_get_file_attributes_ex,
     utf16_make_tempname,
-    MoveFileExW,
-    SetFileAttributesW,
+    utf16_move_file,
+    utf16_set_file_attributes,
     utf16_strdup
 };
 
@@ -84,7 +90,7 @@ utf16_allocate_tempname(const char *name, size_t extra_chars, size_t *lengthp) {
 }
 
 
-static HANDLE __stdcall utf16_create_file(const char *name, DWORD access, DWORD share_mode, PSECURITY_ATTRIBUTES security_attributes, DWORD creation_disposition, DWORD file_attributes, HANDLE template_file) {
+static HANDLE __stdcall utf16_create_file(const void *name, DWORD access, DWORD share_mode, PSECURITY_ATTRIBUTES security_attributes, DWORD creation_disposition, DWORD file_attributes, HANDLE template_file) {
 #ifdef MS_UWP
     CREATEFILE2_EXTENDED_PARAMETERS extParams = {0};
     extParams.dwFileAttributes = file_attributes;
@@ -100,12 +106,40 @@ static HANDLE __stdcall utf16_create_file(const char *name, DWORD access, DWORD 
 #endif
 }
 
+static BOOL __stdcall
+utf16_delete_file(const void *name)
+{
+    return DeleteFileW((const wchar_t *)name);
+}
+
+static DWORD __stdcall
+utf16_get_file_attributes(const void *name)
+{
+    return GetFileAttributesW((const wchar_t *)name);
+}
+
+static BOOL __stdcall
+utf16_get_file_attributes_ex(const void *name, GET_FILEEX_INFO_LEVELS info_level, void *information)
+{
+    return GetFileAttributesExW((const wchar_t *)name, info_level, information);
+}
 
 static void
 utf16_make_tempname(char *buf, size_t len, const char *name, zip_uint32_t i) {
     _snwprintf_s((wchar_t *)buf, len, len, L"%s.%08x", (const wchar_t *)name, i);
 }
 
+static BOOL __stdcall
+utf16_move_file(const void *from, const void *to, DWORD flags)
+{
+    return MoveFileExW((const wchar_t *)from, (const wchar_t *)to, flags);
+}
+
+static BOOL __stdcall
+utf16_set_file_attributes(const void *name, DWORD attributes)
+{
+    return SetFileAttributesW((const wchar_t *)name, attributes);
+}
 
 static char *
 utf16_strdup(const char *string) {


### PR DESCRIPTION
When building with GCC14 to MinGW, the build currently fails due to multiple initializations of incompatible pointer types such as

```
/builddir/build/BUILD/mingw-libzip-1.10.1-build/libzip-1.10.1/lib/zip_source_file_win32_utf16.c:46:5: error: initialization of 'void * (__attribute__((stdcall)) *)(const void *, DWORD,  DWORD,  struct _SECURITY_ATTRIBUTES *, DWORD,  DWORD,  void *)' {aka 'void * (__attribute__((stdcall)) *)(const void *, long unsigned int,  long unsigned int,  struct _SECURITY_ATTRIBUTES *, long unsigned int,  long unsigned int,  void *)'} from incompatible pointer type 'void * (__attribute__((stdcall)) *)(const char *, DWORD,  DWORD,  struct _SECURITY_ATTRIBUTES *, DWORD,  DWORD,  void *)' {aka 'void * (__attribute__((stdcall)) *)(const char *, long unsigned int,  long unsigned int,  struct _SECURITY_ATTRIBUTES *, long unsigned int,  long unsigned int,  void *)'} [-Wincompatible-pointer-types]
   46 |     utf16_create_file,
      |     ^~~~~~~~~~~~~~~~~
```

See also https://kojipkgs.fedoraproject.org//work/tasks/1551/120721551/build.log
