### PR TITLE
Fix appveyor vcpkg cache directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ os:
 
 environment:
   PATH: C:\Python311-x64\Scripts;C:\Python311-arm\Scripts;$(PATH)
+  VCPKG_BINARY_SOURCES: clear;files,C:\vcpkg.cache,readwrite
   matrix:
     - GENERATOR: "Visual Studio 16 2019"
       PLATFORM: x64
@@ -65,8 +66,6 @@ before_build:
   cmd: >-
     py -m pip install nihtest
 
-    vcpkg install
-
     mkdir build
 
     cd build
@@ -90,4 +89,4 @@ test_script:
     IF %RUN_TESTS%==yes ( ctest -C %CMAKE_CONFIG% --output-on-failure )
 
 cache:
-  - c:\tools\vcpkg\installed\
+  - c:\vcpkg.cache -> vcpkg.json


### PR DESCRIPTION
vcpkg in manifest mode creates the vcpkg_installed directory in the build directory

Amend commit https://github.com/nih-at/libzip/commit/d0ab65517578f7548380aa61d3aef9065f9927cd

CMake configure step exposed the vcpkg_installed directory in appveyor logs:
-- Found ZLIB: optimized;C:/projects/libzip/**build/vcpkg_installed**/x64-windows/lib/zlib.lib;debug;C:/projects/libzip/**build/vcpkg_installed**/x64-windows/debug/lib/zlibd.lib (found suitable version "1.3.1", minimum required is "1.1.2")
