### PR TITLE
libzip-config: Fix variable substitutions

### DIFF
--- a/libzip-config.cmake.in
+++ b/libzip-config.cmake.in
@@ -1,17 +1,17 @@
 @PACKAGE_INIT@
 
 # We need to supply transitive dependencies if this config is for a static library
-set(IS_SHARED @BUILD_SHARED_LIBS@)
+set(IS_SHARED "@BUILD_SHARED_LIBS@")
 if (NOT IS_SHARED)
   include(CMakeFindDependencyMacro)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
 
-  set(ENABLE_BZIP2 @BZIP2_FOUND@)
-  set(ENABLE_LZMA @LIBLZMA_FOUND@)
-  set(ENABLE_ZSTD @ZSTD_FOUND@)
-  set(ENABLE_GNUTLS @GNUTLS_FOUND@)
-  set(ENABLE_MBEDTLS @MBEDTLS_FOUND@)
-  set(ENABLE_OPENSSL @OPENSSL_FOUND@)
+  set(ENABLE_BZIP2 "@BZIP2_FOUND@")
+  set(ENABLE_LZMA "@LIBLZMA_FOUND@")
+  set(ENABLE_ZSTD "@ZSTD_FOUND@")
+  set(ENABLE_GNUTLS "@GNUTLS_FOUND@")
+  set(ENABLE_MBEDTLS "@MBEDTLS_FOUND@")
+  set(ENABLE_OPENSSL "@OPENSSL_FOUND@")
 
   find_dependency(ZLIB 1.1.2)
   if(ENABLE_BZIP2)


### PR DESCRIPTION
When `@variables@` are not set, or set to an empty value, during configuration, the resulting substition is '`set(VARIABLE )`'. This unsets the variable in the current scope when the config is used, make visible values from the parent scope. What is needed is setting variables to an empty value in the current scope. This is achieved by adding quotes.