### PR TITLE
Fix memory leak on multiple call to zip_file_set_encryption

### DIFF
--- a/lib/zip_file_set_encryption.c
+++ b/lib/zip_file_set_encryption.c
@@ -80,17 +80,17 @@ zip_file_set_encryption(zip_t *za, zip_uint64_t idx, zip_uint16_t method, const 
 
     e->changes->encryption_method = method;
     e->changes->changed |= ZIP_DIRENT_ENCRYPTION_METHOD;
+    if (e->changes->changed & ZIP_DIRENT_PASSWORD) {
+        _zip_crypto_clear(e->changes->password, strlen(e->changes->password));
+        free(e->changes->password);
+    }
     if (password) {
         e->changes->password = our_password;
         e->changes->changed |= ZIP_DIRENT_PASSWORD;
     }
     else {
-        if (e->changes->changed & ZIP_DIRENT_PASSWORD) {
-            _zip_crypto_clear(e->changes->password, strlen(e->changes->password));
-            free(e->changes->password);
-            e->changes->password = e->orig ? e->orig->password : NULL;
-            e->changes->changed &= ~ZIP_DIRENT_PASSWORD;
-        }
+        e->changes->password = e->orig ? e->orig->password : NULL;
+        e->changes->changed &= ~ZIP_DIRENT_PASSWORD;
     }
 
     return 0;


### PR DESCRIPTION
If password is set twice, the first allocation is never freed

Reported as https://github.com/php/php-src/issues/19932

PHP use as workaround to free the first password:

     zip_file_set_encryption(intern, index, ZIP_EM_NONE, NULL)