### PR TITLE
Fix trailing null byte to space conversion

### DIFF
--- a/lib/zip_io_util.c
+++ b/lib/zip_io_util.c
@@ -93,11 +93,15 @@ _zip_read_data(zip_buffer_t *buffer, zip_source_t *src, size_t length, bool nulp
     }
 
     if (nulp) {
+        zip_uint8_t *last_non_null = r + length;
+        while (last_non_null > r && *(last_non_null - 1) == '\0')
+            last_non_null--;
+
         zip_uint8_t *o;
-        /* replace any in-string NUL characters with spaces */
+        /* replace any leading or middle in-string NUL characters with spaces */
         r[length] = 0;
         for (o = r; o < r + length; o++)
-            if (*o == '\0')
+            if (*o == '\0' && o < last_non_null)
                 *o = ' ';
     }
 


### PR DESCRIPTION
Preserve trailing null bytes in zip file names instead of converting them to spaces, aligning with unzip/7z behavior.

ISSUE: 505

## Demonstration:
### test.zip contents:
| Filename | Comment |
|----------|---------|
| `trailing_nulls.txt\x00\x00\x00\x00\x00\x00` | 6 trailing null bytes |
| `trailing_space_and_nulls.txt\x20\x00\x00\x00\x00\x00` | Trailing space and 5 trailing null bytes |
| `trailing_spaces_and_nulls.txt\x20\x20\x20\x00\x00\x00` | 3 trailing spaces and 3 trailing null bytes |
| `no_trailing.txt` | No special characters (regular filename) |
| `mid\x00lle_null.txt` | Middle null byte |
| `\x00leading_null.txt` | Leading null byte |
### Extraction result:
| Tool | File Structure | Comment |
|------|----------------| ------- |
| `unzip` | "mid"<br>"no_trailing.txt"<br>"trailing_nulls.txt"<br>"trailing_space_and_nulls.txt&nbsp;"<br>"trailing_spaces_and_nulls.txt&nbsp;&nbsp;&nbsp;" | 1. only **"\x00leading_null.txt"** file is missing <br>2. **"mid\x00lle_null.txt"** filename got trimmed|
| `7zip` | "mid"<br>"no_trailing.txt"<br>"test"<br>"trailing_nulls.txt"<br>"trailing_space_and_nulls.txt&nbsp;"<br>"trailing_spaces_and_nulls.txt&nbsp;&nbsp;&nbsp;" | 1. **"\x00leading_null.txt"** extracts under name **"test"** (from test.zip i guess) <br>2. **"mid\x00lle_null.txt"** filename got trimmed to **"mid"**  |
| `ark (using libzip)` | "&nbsp;leading_null.txt"<br>"mid lle_null.txt"<br>"no_trailing.txt"<br>"trailing_nulls.txt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"<br>"trailing_space_and_nulls.txt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"<br>"trailing_spaces_and_nulls.txt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" | all null bytes were replaced with spaces. file extension parsing failure (sometimes) |
| `ark_fixed (using libzip)` | "&nbsp;leading_null.txt"<br>"mid lle_null.txt"<br>"no_trailing.txt"<br>"trailing_nulls.txt"<br>"trailing_space_and_nulls.txt&nbsp;"<br>"trailing_spaces_and_nulls.txt&nbsp;&nbsp;&nbsp;" | we now handle trailing null bytes like unzip and 7z. all other null positions (middle, leading) get consistent processing (replaced with spaces)|
## How to reproduce: 
<details> 
  <summary>Spoiler </summary>
   install dependencies, create script, set **libzip_build_path** value and you are ready to go. also, this archive is attached.
   
   ```
   #!/bin/bash
   
   # You might need to install Archive::Zip first: sudo cpan Archive::Zip
   perl -MArchive::Zip -e '
   my $zip = Archive::Zip->new();
   
   my $member1 = $zip->addString("6 trailing null bytes", "trailing_nulls.txt\x00\x00\x00\x00\x00\x00");
   $member1->desiredCompressionMethod(8);
   
   
   my $member2 = $zip->addString("trailing space and 5 trailing null bytes", "trailing_space_and_nulls.txt\x20\x00\x00\x00\x00\x00");
   $member2->desiredCompressionMethod(8);
   
   
   my $member3 = $zip->addString("3 trailing spaces and 3 trailing null bytes ", "trailing_spaces_and_nulls.txt\x20\x20\x20\x00\x00\x00");
   $member3->desiredCompressionMethod(8);
   
   my $member4 = $zip->addString("no trailing bytes", "no_trailing.txt");
   $member4->desiredCompressionMethod(8);
   
   my $member5 = $zip->addString("middle null byte", "mid\x00lle_null.txt");
   $member5->desiredCompressionMethod(8);
   
   my $member6 = $zip->addString("leading null byte", "\x00leading_null.txt");
   $member6->desiredCompressionMethod(8);
   
   
   
   $zip->writeToFileNamed("test.zip");
   print "Success\n";
   '
   zip_path="$(pwd)/test.zip"
   libzip_build_path=""
   
   
   # extract with unzip
   rm -rf ./unzip
   unzip test.zip -d ./unzip
   # extract with 7zip
   rm -rf ./7zip
   7z x test.zip -o./7zip
   
   # extract with original ark cli
   rm -rf ./ark
   mkdir ark
   ark -b -o "./ark" "$zip_path"
   clear
   # test with original ziptool
   echo "ziptool before"
   ziptool -r "$zip_path" stat 0
   ziptool -r "$zip_path" stat 1
   ziptool -r "$zip_path" stat 2
   ziptool -r "$zip_path" stat 3
   ziptool -r "$zip_path" stat 4
   ziptool -r "$zip_path" stat 5
   
   # extract with local libzip
   rm -rf ./ark_fixed
   mkdir ark_fixed
   export LD_LIBRARY_PATH=$libzip_build_path/lib:$LD_LIBRARY_PATH
   ark -b -o "./ark_fixed" "$zip_path"
   
   
   
   
   # test with new ziptool
   echo "ziptool after"
   $libzip_build_path/src/ziptool -r "$zip_path" stat 0
   $libzip_build_path/src/ziptool -r "$zip_path" stat 1
   $libzip_build_path/src/ziptool -r "$zip_path" stat 2
   $libzip_build_path/src/ziptool -r "$zip_path" stat 3
   $libzip_build_path/src/ziptool -r "$zip_path" stat 4
   $libzip_build_path/src/ziptool -r "$zip_path" stat 5
   
   # compare trees
   tree -Q unzip 7zip ark ark_fixed
   
```
</details>

[test.zip](https://github.com/user-attachments/files/22783962/test.zip)
