### PR TITLE
Fix strdup failed

### DIFF
--- a/src/zipcmp.c
+++ b/src/zipcmp.c
@@ -419,6 +419,10 @@ list_directory(const char *name, struct archive *a) {
     }
 
     normalized_name = strdup(name);
+    if (normalized_name == NULL) {
+        fprintf(stderr, "%s: malloc failure\n", progname);
+        exit(1);
+    }
 
     while (name_length > 0 && normalized_name[name_length-1] == '/') {
         name_length -= 1;


### PR DESCRIPTION
As for `libzip`, it pays great attention to memory management. This PR aims to correct the early exit after memory allocation failure due to `strdup`.