### PR TITLE
cmake: bump minimum required for examples to version 3.5.0

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
 foreach(PROGRAM add-compressed-data autoclose-archive in-memory)
     add_executable(${PROGRAM} ${PROGRAM}.c)
     target_link_libraries(${PROGRAM} zip)


### PR DESCRIPTION
This follows #392, and it was originally reported to the [Debian BTS](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1125640) but somehow not forwarded until now.