### PR TITLE
Fix uint16 overflow in _zip_ef_size() extra field accumulator

### DIFF
--- a/lib/zip_extra_field.c
+++ b/lib/zip_extra_field.c
@@ -307,16 +307,19 @@ zip_extra_field_t *_zip_ef_remove_internal(zip_extra_field_t *ef) {
 
 
 zip_uint16_t _zip_ef_size(const zip_extra_field_t *ef, zip_flags_t flags) {
-    zip_uint16_t size;
+    zip_uint32_t size;
 
     size = 0;
     for (; ef; ef = ef->next) {
         if (ef->flags & flags & ZIP_EF_BOTH) {
-            size = (zip_uint16_t)(size + 4 + ef->size);
+            size += 4 + ef->size;
         }
     }
 
-    return size;
+    if (size > ZIP_UINT16_MAX) {
+        return ZIP_UINT16_MAX;
+    }
+    return (zip_uint16_t)size;
 }
 
 


### PR DESCRIPTION
`_zip_ef_size()` at `lib/zip_extra_field.c:309` accumulates extra field sizes into a `zip_uint16_t`. When the total exceeds 65535, the value wraps around silently. This is noted by the `TODO: check for overflow` comment at `zip_dirent.c:1075`.

Fix: accumulate into `zip_uint32_t` and cap the return value at `ZIP_UINT16_MAX`.