### PR TITLE
Fix zstd::libzstd_shared not found error on CYGWIN

### DIFF
--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -152,7 +152,7 @@ find_package_handle_standard_args(zstd
 
 if(zstd_FOUND AND zstd_SHARED_LIBRARY AND NOT TARGET zstd::libzstd_shared)
   add_library(zstd::libzstd_shared SHARED IMPORTED)
-  if(WIN32)
+  if(WIN32 OR CYGWIN)
     set_target_properties(zstd::libzstd_shared PROPERTIES
       IMPORTED_LOCATION "${zstd_DLL}"
       IMPORTED_IMPLIB "${zstd_SHARED_LIBRARY}"


### PR DESCRIPTION
I tried to update the package of libzip for CYGWIN, but I got an error when I executed ninja for building.
When CMake configures the build, it prints this message on the console:
```
-- Found zstd: /usr/lib/libzstd.dll.a (Required is at least version "1.4.0")
```
and I have installed version zstd-1.5.7 in my environment.
However, when I start the real build process, it prints this error message:
```
ninja: error: 'zstd::libzstd_shared-NOTFOUND', needed by 'lib/cygzip-5.dll', missing and no known rule to make it
```
The bug happens because CYGWIN uses DLLs and import libraries like MinGW.
So I fixed the bug into `cmake/Findzstd.cmake` with this patch.