### PR TITLE
zero pkware password before free in trad_pkware_free

### DIFF
--- a/lib/zip_source_pkware_decode.c
+++ b/lib/zip_source_pkware_decode.c
@@ -222,6 +222,7 @@ static void trad_pkware_free(struct trad_pkware *ctx) {
         return;
     }
 
+    _zip_crypto_clear(ctx->password, strlen(ctx->password));
     free(ctx->password);
     free(ctx);
 }

--- a/lib/zip_source_pkware_encode.c
+++ b/lib/zip_source_pkware_encode.c
@@ -252,6 +252,7 @@ static void trad_pkware_free(struct trad_pkware *ctx) {
         return;
     }
 
+    _zip_crypto_clear(ctx->password, strlen(ctx->password));
     free(ctx->password);
     _zip_buffer_free(ctx->buffer);
     zip_error_fini(&ctx->error);


### PR DESCRIPTION
winzip_aes_free and _zip_dirent_finalize zero the strdup'd password
with _zip_crypto_clear before free; the two trad_pkware_free helpers
in zip_source_pkware_(de|en)code drop the password directly, leaving
the plaintext in heap memory after free. Apply the same clear-then-free
pattern in both pkware paths so all four encryption contexts match.