### PR TITLE
fix out-of-bounds read in zip_dir_add for empty name

### DIFF
--- a/lib/zip_dir_add.c
+++ b/lib/zip_dir_add.c
@@ -58,7 +58,7 @@ ZIP_EXTERN zip_int64_t zip_dir_add(zip_t *za, const char *name, zip_flags_t flag
     s = NULL;
     len = strlen(name);
 
-    if (name[len - 1] != '/') {
+    if (len == 0 || name[len - 1] != '/') {
         if (len > SIZE_MAX - 2 || (s = (char *)malloc(len + 2)) == NULL) {
             zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
             return -1;


### PR DESCRIPTION
zip_dir_add() reads name[len - 1] to test for a trailing slash, but len is strlen(name) and is never checked for zero. Passing an empty name makes this name[(size_t)-1], a one-byte out-of-bounds read before the buffer. Guard the access with len == 0 so empty names take the trailing-slash path instead.