### PR TITLE
zero default password before free

### DIFF
--- a/lib/zip_discard.c
+++ b/lib/zip_discard.c
@@ -54,7 +54,7 @@ void zip_discard(zip_t *za) {
         zip_source_free(za->src);
     }
 
-    if (za->default_password) {
+    if (za->default_password != NULL) {
         _zip_crypto_clear(za->default_password, strlen(za->default_password));
     }
     free(za->default_password);

--- a/lib/zip_discard.c
+++ b/lib/zip_discard.c
@@ -33,6 +33,7 @@
 
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "zipint.h"
 
@@ -53,6 +54,9 @@ void zip_discard(zip_t *za) {
         zip_source_free(za->src);
     }
 
+    if (za->default_password) {
+        _zip_crypto_clear(za->default_password, strlen(za->default_password));
+    }
     free(za->default_password);
     _zip_string_free(za->comment_orig);
     _zip_string_free(za->comment_changes);

--- a/lib/zip_set_default_password.c
+++ b/lib/zip_set_default_password.c
@@ -43,7 +43,7 @@ ZIP_EXTERN int zip_set_default_password(zip_t *za, const char *passwd) {
         return -1;
     }
 
-    if (za->default_password) {
+    if (za->default_password != NULL) {
         _zip_crypto_clear(za->default_password, strlen(za->default_password));
     }
     free(za->default_password);

--- a/lib/zip_set_default_password.c
+++ b/lib/zip_set_default_password.c
@@ -43,6 +43,9 @@ ZIP_EXTERN int zip_set_default_password(zip_t *za, const char *passwd) {
         return -1;
     }
 
+    if (za->default_password) {
+        _zip_crypto_clear(za->default_password, strlen(za->default_password));
+    }
     free(za->default_password);
 
     if (passwd && passwd[0] != '\0') {


### PR DESCRIPTION
za->default_password keeps the strdup'd cleartext decryption password (set via zip_set_default_password, used in zip_close.c and zip_fopen.c) but is freed without wiping in zip_set_default_password and zip_discard, unlike every other password/key path which already calls _zip_crypto_clear before free.