### PR TITLE
clear keystream state before free in _zip_winzip_aes_free

### DIFF
--- a/lib/zip_winzip_aes.c
+++ b/lib/zip_winzip_aes.c
@@ -156,5 +156,6 @@ void _zip_winzip_aes_free(zip_winzip_aes_t *ctx) {
 
     _zip_crypto_aes_free(ctx->aes);
     _zip_crypto_hmac_free(ctx->hmac);
+    _zip_crypto_clear(ctx, sizeof(*ctx));
     free(ctx);
 }


### PR DESCRIPTION
The _zip_winzip_aes context keeps the AES-CTR counter and the current keystream block (pad, which is E(counter)) used to en/decrypt entry data. _zip_winzip_aes_free releases it with a plain free, leaving that material in the freed allocation. The error path in _zip_winzip_aes_new already clears the whole ctx a few lines up, and _zip_crypto_aes_free and _zip_crypto_hmac_free both wipe their structs, so only the normal free path was missing the same step.