### PR TITLE
reject filenames longer than 65535 bytes in _zip_set_name

### DIFF
--- a/lib/zip_set_name.c
+++ b/lib/zip_set_name.c
@@ -57,7 +57,10 @@ int _zip_set_name(zip_t *za, zip_uint64_t idx, const char *name, zip_flags_t fla
     }
 
     if (name && name[0] != '\0') {
-        /* TODO: check for string too long */
+        if (strlen(name) > ZIP_UINT16_MAX) {
+            zip_error_set(&za->error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
         if ((str = _zip_string_new((const zip_uint8_t *)name, (zip_uint16_t)strlen(name), flags, &za->error)) == NULL) {
             return -1;
         }


### PR DESCRIPTION
noticed the `TODO: check for string too long` in `_zip_set_name` is real: it narrows `strlen(name)` to `zip_uint16_t`, so `zip_file_add`/`zip_dir_add` silently truncate a name over 65535 bytes to a different (possibly colliding) entry, while `zip_file_rename` already rejects it at its entry point, so add the same guard in the callee.