### PR TITLE
Use a constant-time comparison for WinZip AES authentication tag verification

### DIFF
--- a/lib/zip_source_winzip_aes_decode.c
+++ b/lib/zip_source_winzip_aes_decode.c
@@ -129,6 +129,21 @@ static int decrypt_header(zip_source_t *src, struct winzip_aes *ctx) {
 }
 
 
+/* Compare two byte sequences in constant time, without leaking through timing
+   how many leading bytes matched. Used for authentication tag (MAC) comparison
+   to avoid a timing side channel. Returns true if the sequences are equal. */
+static bool secure_equal(const unsigned char *a, const unsigned char *b, size_t length) {
+    unsigned char diff = 0;
+    size_t i;
+
+    for (i = 0; i < length; i++) {
+        diff |= (unsigned char)(a[i] ^ b[i]);
+    }
+
+    return diff == 0;
+}
+
+
 static bool verify_hmac(zip_source_t *src, struct winzip_aes *ctx) {
     unsigned char computed[ZIP_CRYPTO_SHA1_LENGTH], from_file[HMAC_LENGTH];
     if (zip_source_read(src, from_file, HMAC_LENGTH) < HMAC_LENGTH) {
@@ -143,7 +158,10 @@ static bool verify_hmac(zip_source_t *src, struct winzip_aes *ctx) {
     _zip_winzip_aes_free(ctx->aes_ctx);
     ctx->aes_ctx = NULL;
 
-    if (memcmp(from_file, computed, HMAC_LENGTH) != 0) {
+    /* The authentication tag must be compared in constant time so that the
+       number of matching leading bytes does not leak through timing, which
+       could otherwise enable byte-by-byte forgery of the MAC. */
+    if (!secure_equal(from_file, computed, HMAC_LENGTH)) {
         zip_error_set(&ctx->error, ZIP_ER_CRC, 0);
         return false;
     }


### PR DESCRIPTION
## Overview

This change makes the WinZip AES authentication-tag verification in
`lib/zip_source_winzip_aes_decode.c` run in constant time, removing a timing
side channel from MAC comparison.

## Background

When libzip reads a WinZip AES (AE-1/AE-2) encrypted entry, each entry ends with
an authentication code: a truncated HMAC-SHA1 of `HMAC_LENGTH` (10) bytes. After
decrypting the data, `verify_hmac()` recomputes the HMAC and compares it against
the value stored in the archive. If they differ, the entry is rejected with
`ZIP_ER_CRC`. This comparison is the integrity check that detects tampered or
corrupted ciphertext, so it is a genuine MAC verification.

## Problem

The comparison was performed with `memcmp()`:

```c
if (memcmp(from_file, computed, HMAC_LENGTH) != 0) {
```

`memcmp()` is allowed to return as soon as it encounters the first differing
byte. Its execution time therefore depends on how many leading bytes of the two
tags match. For a MAC comparison this is a classic timing side channel: an
attacker who can supply many crafted entries and measure how long verification
takes can learn the tag prefix one byte at a time, and in principle forge a valid
authentication tag without knowing the key.

This is the same reason cryptographic libraries provide dedicated helpers for
this purpose (for example OpenSSL's `CRYPTO_memcmp()` and the BSD
`timingsafe_bcmp()`): MAC and tag comparisons should not short-circuit on the
first mismatching byte. libzip currently has no constant-time comparison helper,
so the comparison falls back to `memcmp()`.

## Change

A small, branchless helper is added and used for the tag comparison:

```c
static bool secure_equal(const unsigned char *a, const unsigned char *b, size_t length) {
    unsigned char diff = 0;
    size_t i;

    for (i = 0; i < length; i++) {
        diff |= (unsigned char)(a[i] ^ b[i]);
    }

    return diff == 0;
}
```

It always inspects every byte and accumulates the per-byte differences, so its
running time depends only on `length`, not on the contents.

The earlier password-verification comparison in `decrypt_header()` is left as
`memcmp()` on purpose: that 16-bit value is a non-authenticating quick-reject
defined by the WinZip AES format, not the integrity tag. The HMAC checked in
`verify_hmac()` is the actual authenticator, so it is the comparison that needs
constant-time handling. I'm happy to convert the verification-value comparison as
well if you'd prefer the two to be consistent.

## Behavioural equivalence

The change is functionally identical to the previous code: `!secure_equal(a, b, n)`
is true for exactly the same inputs as `memcmp(a, b, n) != 0`. The same tags are
accepted and the same tags are rejected; only the timing characteristic changes.
There are no API or ABI changes.

## Testing

- Builds cleanly with no new warnings.
- Verified an AES-256 round trip: an entry encrypted with a password decrypts and
  verifies with the correct password, and is rejected with a wrong password —
  identical results before and after the change.

## Checklist

- [ ] CLA signed
- [x] No API or ABI changes
- [x] No behavioural change (timing characteristic only)
