### PR TITLE
ossfuzz: add zip_source_zip_fuzzer for partial-window extraction paths

### DIFF
--- a/ossfuzz/CMakeLists.txt
+++ b/ossfuzz/CMakeLists.txt
@@ -2,6 +2,7 @@ set(FUZZ_PROGRAMS
   zip_read_file_fuzzer
   zip_read_fuzzer
   zip_read_metadata_fuzzer
+  zip_source_zip_fuzzer
   zip_write_encrypt_aes256_file_fuzzer
   zip_write_encrypt_pkware_file_fuzzer
   zip_write_roundtrip_fuzzer

--- a/ossfuzz/zip_source_zip_fuzzer.c
+++ b/ossfuzz/zip_source_zip_fuzzer.c
@@ -1,0 +1,123 @@
+/*
+  zip_source_zip_fuzzer.c -- fuzz the zip_source_zip windowing/extraction paths
+  Copyright (C) 2026 The libzip Authors
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  Coverage gap addressed:
+    zip_read_fuzzer.c and zip_read_file_fuzzer.c read entries through
+    zip_fopen_index(), which always calls zip_source_zip_file_create()
+    with the fixed arguments (flags = 0, start = 0, len = -1).  As a
+    result the partial-window and raw-extraction logic in
+    zip_source_zip_new.c is never exercised by any harness:
+
+      - start > 0 / len >= 0   (reading a sub-range of an entry; the
+                                window source offset arithmetic and the
+                                overflow / past-end-of-file checks)
+      - ZIP_FL_COMPRESSED      (returning the raw compressed bytes wrapped
+                                in a window instead of decompressing)
+      - ZIP_FL_UNCHANGED       (stat/dirent selection for the original
+                                on-disk entry)
+      - the public zip_source_zip_create() entry point itself
+
+    These paths combine attacker-controlled start/len with sizes parsed
+    from the central directory and then layer window -> decrypt ->
+    decompress -> crc sources on top, so they are worth fuzzing directly.
+
+  Strategy:
+    Open the fuzz input as a read-only archive and, for every entry,
+    create a zip_source_zip for several flag / start / len combinations
+    derived from the entry's stated size (in-range partial ranges as well
+    as boundary and past-the-end ranges).  Each resulting source is then
+    opened and drained through the source interface so the window,
+    decrypt, decompress and crc layers actually run.
+*/
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <zip.h>
+
+static const char *PASSWORD = "fuzzpw";
+
+/* Create a zip_source_zip for the given parameters and, if it succeeds,
+   drive it through the source interface so every layer is exercised. */
+static void
+exercise(zip_t *za, zip_uint64_t idx, zip_flags_t flags, zip_uint64_t start, zip_int64_t len) {
+    zip_error_t error;
+    zip_source_t *src;
+
+    zip_error_init(&error);
+    src = zip_source_zip_create(za, idx, flags, start, len, &error);
+    zip_error_fini(&error);
+    if (src == NULL) {
+        return;
+    }
+
+    if (zip_source_open(src) == 0) {
+        char buf[4096];
+        while (zip_source_read(src, buf, sizeof(buf)) > 0) {
+            ;
+        }
+        zip_source_close(src);
+    }
+
+    zip_source_free(src);
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    zip_error_t error;
+    zip_source_t *src;
+    zip_t *za;
+    zip_int64_t n, i;
+
+    zip_error_init(&error);
+
+    src = zip_source_buffer_create(data, size, 0, &error);
+    if (src == NULL) {
+        zip_error_fini(&error);
+        return 0;
+    }
+
+    za = zip_open_from_source(src, 0, &error);
+    if (za == NULL) {
+        zip_source_free(src);
+        zip_error_fini(&error);
+        return 0;
+    }
+    zip_error_fini(&error);
+
+    zip_set_default_password(za, PASSWORD);
+
+    n = zip_get_num_entries(za, 0);
+    for (i = 0; i < n; i++) {
+        zip_uint64_t idx = (zip_uint64_t)i;
+        zip_stat_t st;
+        zip_uint64_t entry_size = 0;
+
+        if (zip_stat_index(za, idx, 0, &st) == 0 && (st.valid & ZIP_STAT_SIZE)) {
+            entry_size = st.size;
+        }
+
+        /* Whole-entry variants: decode, raw compressed window, original entry. */
+        exercise(za, idx, 0, 0, -1);
+        exercise(za, idx, ZIP_FL_COMPRESSED, 0, -1);
+        exercise(za, idx, ZIP_FL_UNCHANGED, 0, -1);
+
+        /* In-range partial windows: these drive the offset arithmetic. */
+        if (entry_size >= 2) {
+            zip_uint64_t half = entry_size / 2;
+            exercise(za, idx, 0, 1, (zip_int64_t)half);
+            exercise(za, idx, 0, half, (zip_int64_t)(entry_size - half));
+            exercise(za, idx, 0, 0, (zip_int64_t)(entry_size - 1));
+        }
+
+        /* Boundary and past-the-end ranges exercise the rejection paths. */
+        exercise(za, idx, 0, entry_size, 1);
+        exercise(za, idx, 0, entry_size + 1, -1);
+    }
+
+    zip_discard(za);
+    return 0;
+}


### PR DESCRIPTION
## Overview

This adds a new OSS-Fuzz target, `zip_source_zip_fuzzer`, that exercises the
`zip_source_zip` windowing and raw-extraction code in `zip_source_zip_new.c`,
which the current read-side fuzzers do not reach.

## Coverage gap

`zip_read_fuzzer`, `zip_read_file_fuzzer` and `zip_read_metadata_fuzzer` all read
entry data through `zip_fopen_index()`. That path always calls
`zip_source_zip_file_create()` with `flags = 0`, `start = 0` and `len = -1`, i.e.
"decode the whole entry from the beginning". As a result several branches of
`zip_source_zip_file_create()` are never executed during fuzzing:

- **Partial windows** (`start > 0` and/or `len >= 0`): the sub-range offset
  arithmetic and the overflow / past-the-end-of-file checks
  (`start + len < start`, `start + len > st.size`, the `ZIP_INT64_MAX` clamps).
- **`ZIP_FL_COMPRESSED`**: returning the raw compressed bytes wrapped in a window
  source instead of decompressing.
- **`ZIP_FL_UNCHANGED`**: dirent/stat selection for the original on-disk entry.
- **`zip_source_zip_create()`** itself, the public API used to read an entry of
  one archive as a source for another.

These combine caller-supplied `start`/`len` with sizes parsed from the central
directory and then layer window → decrypt → decompress → crc sources on top, so
they are worth fuzzing directly.

## What the target does

For the fuzz input interpreted as an archive, it iterates every entry and, for
each, creates a `zip_source_zip` with several flag / start / len combinations
derived from the entry's stated size:

- whole-entry decode, `ZIP_FL_COMPRESSED` raw window, and `ZIP_FL_UNCHANGED`;
- in-range partial windows (`[1, size/2]`, the second half, `[0, size-1]`);
- boundary and past-the-end ranges (`start == size`, `start == size + 1`) to
  drive the rejection paths.

Each resulting source is opened and drained through the source interface so the
window, decrypt, decompress and crc layers actually run. A default password is
set so encrypted entries reach the decrypt layer.

The target builds on the existing `fuzz_main.c` driver and is registered in
`ossfuzz/CMakeLists.txt`, so `make list-fuzzers` (and therefore `ossfuzz.sh`)
picks it up automatically; no change to `ossfuzz.sh` is required.

## Testing

- Builds cleanly with `-fsanitize=address,undefined` and no new warnings.
- Ran the target over the full `regress/*.zip` set (165 inputs) under
  ASan + UBSan with no harness-side errors or leaks.
- Coverage-guided fuzzing runs on the OSS-Fuzz infrastructure.

## Checklist

- [ ] CLA signed
- [x] New fuzz target only; no library code changes
