### PR TITLE
run check_eocd consistency check under ZIP_CHECKCONS

### DIFF
--- a/lib/zip_open.c
+++ b/lib/zip_open.c
@@ -342,7 +342,7 @@ static bool _zip_read_cdir(zip_t *za, zip_buffer_t *buffer, zip_uint64_t buf_off
 
     /* We accept this EOCD as valid and won't search for an earlier one if it is unusable. */
 
-    if (!check_eocd(cd, za->flags, error)) {
+    if (!check_eocd(cd, za->open_flags, error)) {
         _zip_cdir_free(cd);
         return true;
     }
@@ -802,7 +802,7 @@ static bool check_eocd(zip_cdir_t *cd, unsigned int flags, zip_error_t *error) {
         zip_error_set(error, ZIP_ER_SEEK, EFBIG);
         return false;
     }
-    if ((flags & ZIP_CHECKCONS) && cd->offset + cd->size != cd->eocd_offset) {
+    if ((flags & ZIP_CHECKCONS) && !cd->is_zip64 && cd->offset + cd->size != cd->eocd_offset) {
         zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_CDIR_LENGTH_INVALID);
         return false;
     }

--- a/regress/open_incons.test
+++ b/regress/open_incons.test
@@ -57,8 +57,8 @@ stdout
 opening 'incons-archive-comment-longer.zzip' returned error Zip archive inconsistent: archive comment length incorrect
 opening 'incons-archive-comment-shorter.zzip' returned error Zip archive inconsistent: archive comment length incorrect
 opening 'incons-cdoffset.zzip' returned error Possibly truncated or corrupted zip archive
-opening 'incons-cdsize-large.zzip' returned error Zip archive inconsistent: central directory overlaps EOCD, or there is space between them
-opening 'incons-cdsize-small.zzip' returned error Zip archive inconsistent: central directory overlaps EOCD, or there is space between them
+opening 'incons-cdsize-large.zzip' returned error Zip archive inconsistent: central directory length invalid
+opening 'incons-cdsize-small.zzip' returned error Zip archive inconsistent: central directory length invalid
 opening 'incons-central-compression-method.zzip' returned error Zip archive inconsistent: entry 0: local and central headers do not match
 opening 'incons-central-compsize-larger-toolarge.zzip' returned error Possibly truncated or corrupted zip archive
 opening 'incons-central-compsize-larger.zzip' returned error Zip archive inconsistent: entry 0: local and central headers do not match
@@ -87,7 +87,7 @@ opening 'incons-file-count-high.zzip' returned error Zip archive inconsistent: c
 opening 'incons-file-count-low.zzip' returned error Zip archive inconsistent: central directory count of entries is incorrect
 opening 'incons-file-count-overflow.zzip' returned error Zip archive inconsistent: invalid value in central directory
 opening 'incons-gap-before-cd.zzip' succeeded, 1 entries
-opening 'incons-gap-before-eocd.zzip' succeeded, 1 entries
+opening 'incons-gap-before-eocd.zzip' returned error Zip archive inconsistent: central directory length invalid
 opening 'incons-gap-before-local.zzip' succeeded, 2 entries
 opening 'incons-local-compression-method.zzip' returned error Zip archive inconsistent: entry 0: local and central headers do not match
 opening 'incons-local-compsize-larger.zzip' returned error Zip archive inconsistent: entry 0: local and central headers do not match
@@ -105,5 +105,5 @@ opening 'incons-streamed.zzip' returned error Zip archive inconsistent: entry 0:
 opening 'incons-streamed-2.zzip' returned error Zip archive inconsistent: entry 0: local header and data descriptor do not match
 end-of-inline-data
 stderr
-41 errors
+42 errors
 end-of-inline-data


### PR DESCRIPTION
check_eocd validates that the central directory ends exactly where the EOCD record begins, but only when ZIP_CHECKCONS is requested. It was passed za->flags instead of za->open_flags; bit 0x4 means ZIP_AFL_IS_TORRENTZIP in za->flags and ZIP_CHECKCONS in za->open_flags, and the torrentzip bit isn't set yet when the central directory is read, so the check never ran and an archive with a gap between the central directory and the EOCD was accepted even under ZIP_CHECKCONS. Pass za->open_flags here, the same way _zip_read_eocd64 was already corrected. The check also has to be skipped for Zip64 archives, where the central directory is followed by the Zip64 EOCD record and locator, so cd->offset + cd->size points before the 32-bit EOCD and the comparison would reject valid files.