### PR TITLE
check for overflow when computing seek offsets

### DIFF
--- a/lib/zip_source_seek.c
+++ b/lib/zip_source_seek.c
@@ -68,10 +68,18 @@ zip_int64_t zip_source_seek_compute_offset(zip_uint64_t offset, zip_uint64_t len
 
     switch (args->whence) {
     case SEEK_CUR:
+        if ((args->offset > 0 && (zip_int64_t)offset > ZIP_INT64_MAX - args->offset) || (args->offset < 0 && (zip_int64_t)offset < ZIP_INT64_MIN - args->offset)) {
+            zip_error_set(error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
         new_offset = (zip_int64_t)offset + args->offset;
         break;
 
     case SEEK_END:
+        if ((args->offset > 0 && (zip_int64_t)length > ZIP_INT64_MAX - args->offset) || (args->offset < 0 && (zip_int64_t)length < ZIP_INT64_MIN - args->offset)) {
+            zip_error_set(error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
         new_offset = (zip_int64_t)length + args->offset;
         break;
 

--- a/lib/zip_source_window.c
+++ b/lib/zip_source_window.c
@@ -275,7 +275,7 @@ static zip_int64_t window_read(zip_source_t *src, void *_ctx, void *data, zip_ui
             }
             else {
                 if (args->whence == SEEK_CUR) {
-                    if (args->offset > 0 && (zip_int64_t)ctx->offset + args->offset < args->offset) {
+                    if (args->offset > 0 && (zip_int64_t)ctx->offset > ZIP_INT64_MAX - args->offset) {
                         zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
                         return -1;
                     }


### PR DESCRIPTION
zip_source_seek_compute_offset() forms the target as (zip_int64_t)offset + args->offset for SEEK_CUR and (zip_int64_t)length + args->offset for SEEK_END without guarding the addition, so a seek with a large delta (reachable via zip_fseek/zip_source_seek on a stored entry) overflows zip_int64_t; UBSan flags it at zip_source_seek.c:71. The window source repeats the same mistake in its SEEK_CUR guard, which does the overflowing add to detect the overflow. This checks the operands against ZIP_INT64_MAX/ZIP_INT64_MIN first, so out-of-range seeks return ZIP_ER_INVAL as before and valid seeks are unaffected.