### PR TITLE
Limit xz decoder memory usage

### DIFF
--- a/lib/zip_algorithm_xz.c
+++ b/lib/zip_algorithm_xz.c
@@ -53,6 +53,12 @@ enum header_state {
 #define HEADER_SIZE_LENGTH 8
 #define HEADER_PARAMETERS_LENGTH 5
 #define HEADER_LZMA_ALONE_LENGTH (HEADER_PARAMETERS_LENGTH + HEADER_SIZE_LENGTH)
+/*
+ * Keep attacker-controlled decoder state bounded. libzip's own preset-based
+ * encoder uses at most a 64 MiB dictionary, so allowing double that preserves
+ * headroom while avoiding multi-gigabyte allocations on crafted input.
+ */
+#define MAX_DECOMPRESS_MEMORY (UINT64_C(128) * 1024 * 1024)
 
 struct ctx {
     zip_error_t *error;
@@ -173,6 +179,7 @@ static int map_error(lzma_ret ret) {
     switch (ret) {
     case LZMA_DATA_ERROR:
     case LZMA_UNSUPPORTED_CHECK:
+    case LZMA_MEMLIMIT_ERROR:
         return ZIP_ER_COMPRESSED_DATA;
 
     case LZMA_MEM_ERROR:
@@ -213,10 +220,10 @@ static bool start(void *ud, zip_stat_t *st, zip_file_attributes_t *attributes) {
     }
     else {
         if (ctx->method == ZIP_CM_LZMA) {
-            ret = lzma_alone_decoder(&ctx->zstr, UINT64_MAX);
+            ret = lzma_alone_decoder(&ctx->zstr, MAX_DECOMPRESS_MEMORY);
         }
         else {
-            ret = lzma_stream_decoder(&ctx->zstr, UINT64_MAX, LZMA_CONCATENATED);
+            ret = lzma_stream_decoder(&ctx->zstr, MAX_DECOMPRESS_MEMORY, LZMA_CONCATENATED);
         }
     }
 

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_PROGRAMS
   can_clone_file
   fopen_unchanged
   fseek
+  lzma_large_dict
 )
 
 set(GETOPT_USERS

--- a/regress/lzma-large-dict.test
+++ b/regress/lzma-large-dict.test
@@ -1,0 +1,2 @@
+program lzma_large_dict
+return 0

--- a/regress/programs/lzma_large_dict.c
+++ b/regress/programs/lzma_large_dict.c
@@ -1,0 +1,102 @@
+/*
+  lzma_large_dict.c -- regression test for oversized LZMA dictionary headers
+  Copyright (C) 2026 Dieter Baron and Thomas Klausner
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+  The authors can be contacted at <info@libzip.org>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+  3. The names of the authors may not be used to endorse or promote
+     products derived from this software without specific prior
+     written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+
+#include <stdio.h>
+
+#include "zip.h"
+
+static const zip_uint8_t lzma_large_dict_archive[] = {
+    0x50, 0x4b, 0x03, 0x04, 0x3f, 0x00, 0x02, 0x00, 0x0e, 0x00, 0x89, 0x8a, 0x36, 0x4f, 0x28, 0xe2, 0xde, 0xa0, 0x21, 0x00, 0x00, 0x00, 0x40,
+    0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x61, 0x62, 0x61, 0x63, 0x2d, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x2e, 0x74, 0x78, 0x74, 0x09,
+    0x14, 0x05, 0x00, 0x5d, 0x00, 0x00, 0x04, 0xa1, 0x00, 0x00, 0x00, 0xbd, 0xa0, 0xa3, 0x19, 0xd7, 0x9c, 0xf2, 0xec, 0x93, 0x6b, 0xfe, 0x83,
+    0x68, 0x26, 0x2f, 0xff, 0xff, 0x33, 0x14, 0x00, 0x00, 0x50, 0x4b, 0x01, 0x02, 0x3f, 0x00, 0x3f, 0x00, 0x02, 0x00, 0x0e, 0x00, 0x89, 0x8a,
+    0x36, 0x4f, 0x28, 0xe2, 0xde, 0xa0, 0x21, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x61, 0x62, 0x61, 0x63, 0x2d, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x2e, 0x74, 0x78,
+    0x74, 0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x3d, 0x00, 0x00, 0x00, 0x4e, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+int main(void) {
+    zip_error_t error;
+    zip_source_t *src;
+    zip_t *za;
+    zip_file_t *zf;
+    zip_error_t *zf_error;
+    char buf[32];
+    zip_int64_t n;
+
+    zip_error_init(&error);
+    src = zip_source_buffer_create(lzma_large_dict_archive, sizeof(lzma_large_dict_archive), 0, &error);
+    if (src == NULL) {
+        fprintf(stderr, "zip_source_buffer_create failed: %s\n", zip_error_strerror(&error));
+        zip_error_fini(&error);
+        return 1;
+    }
+
+    za = zip_open_from_source(src, 0, &error);
+    if (za == NULL) {
+        fprintf(stderr, "zip_open_from_source failed: %s\n", zip_error_strerror(&error));
+        zip_source_free(src);
+        zip_error_fini(&error);
+        return 1;
+    }
+    zip_error_fini(&error);
+
+    zf = zip_fopen_index(za, 0, 0);
+    if (zf == NULL) {
+        fprintf(stderr, "zip_fopen_index failed: %s\n", zip_strerror(za));
+        zip_discard(za);
+        return 1;
+    }
+
+    n = zip_fread(zf, buf, sizeof(buf));
+    if (n >= 0) {
+        fprintf(stderr, "zip_fread unexpectedly returned %lld bytes\n", (long long)n);
+        (void)zip_fclose(zf);
+        zip_discard(za);
+        return 1;
+    }
+
+    zf_error = zip_file_get_error(zf);
+    if (zip_error_code_zip(zf_error) != ZIP_ER_COMPRESSED_DATA) {
+        fprintf(stderr, "zip_fread failed with unexpected error: %s\n", zip_file_strerror(zf));
+        (void)zip_fclose(zf);
+        zip_discard(za);
+        return 1;
+    }
+
+    (void)zip_fclose(zf);
+    zip_discard(za);
+    return 0;
+}


### PR DESCRIPTION
This change bounds XZ/LZMA decoder memory usage during reads and adds a regression for crafted archives with oversized dictionary headers.

The root cause is that `zip_algorithm_xz.c` initialized both decoders with `UINT64_MAX`, so attacker-controlled stream parameters could drive multi-gigabyte allocation attempts before libzip rejected the input. This patch caps decompressor memory to 128 MiB, which still leaves headroom above libzip's own encoder presets, and treats memlimit failures as compressed-data errors.

Impact:
- crafted XZ/LZMA members fail closed instead of attempting unbounded decoder allocations
- callers receive a normal compressed-data failure instead of resource blowup behavior
- a regression now covers an archive with an oversized dictionary header

Validation:
- `cmake -S . -B build-pr -DNIHTEST=/usr/bin/true`
- `cmake --build build-pr --target lzma_large_dict -j4`
- `./build-pr/regress/lzma_large_dict`
