### PR TITLE
Fix zip_source_is_seekable for non-layered sources

### DIFF
--- a/lib/zip_source_supports.c
+++ b/lib/zip_source_supports.c
@@ -67,5 +67,5 @@ ZIP_EXTERN zip_int64_t zip_source_make_command_bitmap(zip_source_cmd_t cmd0, ...
 
 
 ZIP_EXTERN int zip_source_is_seekable(zip_source_t *src) {
-    return ZIP_SOURCE_CHECK_SUPPORTED(zip_source_supports(src->src), ZIP_SOURCE_SEEK);
+    return ZIP_SOURCE_CHECK_SUPPORTED(zip_source_supports(src), ZIP_SOURCE_SEEK);
 }

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_PROGRAMS
   can_clone_file
   fopen_unchanged
   fseek
+  source_is_seekable
 )
 
 set(GETOPT_USERS

--- a/regress/programs/source_is_seekable.c
+++ b/regress/programs/source_is_seekable.c
@@ -1,0 +1,65 @@
+#include <stdlib.h>
+
+#include "zip.h"
+
+static zip_int64_t
+source_callback(void *ud, void *data, zip_uint64_t length, zip_source_cmd_t command) {
+    zip_error_t *error = (zip_error_t *)ud;
+
+    switch (command) {
+    case ZIP_SOURCE_CLOSE:
+    case ZIP_SOURCE_FREE:
+    case ZIP_SOURCE_OPEN:
+        return 0;
+
+    case ZIP_SOURCE_ERROR:
+        return zip_error_to_data(error, data, length);
+
+    case ZIP_SOURCE_READ:
+        return 0;
+
+    case ZIP_SOURCE_SUPPORTS:
+        return zip_source_make_command_bitmap(ZIP_SOURCE_OPEN, ZIP_SOURCE_READ, ZIP_SOURCE_CLOSE, ZIP_SOURCE_ERROR, ZIP_SOURCE_FREE, -1);
+
+    default:
+        zip_error_set(error, ZIP_ER_OPNOTSUPP, 0);
+        return -1;
+    }
+}
+
+
+int
+main(void) {
+    zip_error_t error;
+    zip_source_t *seekable;
+    zip_source_t *nonseekable;
+
+    zip_error_init(&error);
+
+    seekable = zip_source_buffer_create("A", 1, 0, &error);
+    if (seekable == NULL) {
+        zip_error_fini(&error);
+        return 1;
+    }
+    if (zip_source_is_seekable(seekable) != 1) {
+        zip_source_free(seekable);
+        zip_error_fini(&error);
+        return 1;
+    }
+    zip_source_free(seekable);
+
+    nonseekable = zip_source_function_create(source_callback, &error, &error);
+    if (nonseekable == NULL) {
+        zip_error_fini(&error);
+        return 1;
+    }
+    if (zip_source_is_seekable(nonseekable) != 0) {
+        zip_source_free(nonseekable);
+        zip_error_fini(&error);
+        return 1;
+    }
+    zip_source_free(nonseekable);
+
+    zip_error_fini(&error);
+    return 0;
+}

--- a/regress/source-is-seekable.test
+++ b/regress/source-is-seekable.test
@@ -1,0 +1,3 @@
+description zip_source_is_seekable handles non-layered sources
+program source_is_seekable
+return 0


### PR DESCRIPTION
This change fixes `zip_source_is_seekable()` for non-layered sources and adds a regression that covers both buffer-backed and root callback sources.

The root cause is that the public helper dereferenced `src->src` unconditionally. That only works for layered sources; root sources have no lower layer and can trigger a null dereference. This patch queries `zip_source_supports(src)` directly so the API works for both layered and non-layered sources.

Impact:
- `zip_source_is_seekable()` no longer crashes on root sources
- callers receive the expected seekability result for custom callback sources
- the regression covers both seekable and non-seekable top-level sources

Validation:
- `cmake -S . -B build-pr -DNIHTEST=/usr/bin/true`
- `cmake --build build-pr --target source_is_seekable -j4`
- `./build-pr/regress/source_is_seekable`
