### PR TITLE
Reject local header mismatches on read

### DIFF
--- a/lib/zip_file_get_offset.c
+++ b/lib/zip_file_get_offset.c
@@ -37,6 +37,31 @@
 
 #include "zipint.h"
 
+static bool
+local_header_matches_central(const zip_dirent_t *central, const zip_dirent_t *local) {
+    if ((central->version_needed < local->version_needed)
+        || (central->comp_method != local->comp_method)
+        || (central->last_mod.time != local->last_mod.time)
+        || (central->last_mod.date != local->last_mod.date)
+        || !_zip_string_equal(central->filename, local->filename)) {
+        return false;
+    }
+
+    if ((central->crc != local->crc) || (central->comp_size != local->comp_size) || (central->uncomp_size != local->uncomp_size)) {
+        /* When a data descriptor is used, the local header may contain zeros instead. */
+        if ((local->bitflags & ZIP_GPBF_DATA_DESCRIPTOR) == 0) {
+            return false;
+        }
+        if ((local->crc != 0 && central->crc != local->crc)
+            || (local->comp_size != 0 && central->comp_size != local->comp_size)
+            || (local->uncomp_size != 0 && central->uncomp_size != local->uncomp_size)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 
 /* _zip_file_get_offset(za, ze):
    Returns the offset of the file data for entry ze.
@@ -45,6 +70,7 @@
 */
 
 zip_uint64_t _zip_file_get_offset(const zip_t *za, zip_uint64_t idx, zip_error_t *error) {
+    zip_dirent_t local_dirent;
     zip_uint64_t offset;
     zip_int32_t size;
 
@@ -60,10 +86,23 @@ zip_uint64_t _zip_file_get_offset(const zip_t *za, zip_uint64_t idx, zip_error_t
         return 0;
     }
 
+    _zip_dirent_init(&local_dirent);
+
     /* TODO: cache? */
-    if ((size = _zip_dirent_size(za->src, ZIP_EF_LOCAL, error)) < 0) {
+    if ((size = (zip_int32_t)_zip_dirent_read(&local_dirent, za->src, NULL, true, za->entry[idx].orig->comp_size, false, error)) < 0) {
+        if (zip_error_code_zip(error) == ZIP_ER_INCONS) {
+            zip_error_set(error, ZIP_ER_INCONS, ADD_INDEX_TO_DETAIL(zip_error_code_system(error), idx));
+        }
+        _zip_dirent_finalize(&local_dirent);
         return 0;
     }
+
+    if (!local_header_matches_central(za->entry[idx].orig, &local_dirent)) {
+        zip_error_set(error, ZIP_ER_INCONS, MAKE_DETAIL_WITH_INDEX(ZIP_ER_DETAIL_ENTRY_HEADER_MISMATCH, idx));
+        _zip_dirent_finalize(&local_dirent);
+        return 0;
+    }
+    _zip_dirent_finalize(&local_dirent);
 
     if (offset + (zip_uint32_t)size > ZIP_INT64_MAX) {
         zip_error_set(error, ZIP_ER_SEEK, EFBIG);

--- a/lib/zip_source_file_win32_named.c
+++ b/lib/zip_source_file_win32_named.c
@@ -245,7 +245,7 @@ static zip_int64_t _zip_win32_named_op_write(zip_source_file_context_t *ctx, con
     zip_uint64_t offset = 0;
 
     while (offset < len) {
-        n = (DWORD)ZIP_MIN(len - offset, (zip_uint64_t)DWORD_MAX);
+        n = (DWORD)ZIP_MIN(len - offset, (zip_uint64_t)ZIP_UINT32_MAX);
         if (!WriteFile((HANDLE)ctx->fout, (char *)data + offset, n, &ret, NULL)) {
             zip_error_set(&ctx->error, ZIP_ER_WRITE, _zip_win32_error_to_errno(GetLastError()));
             return -1;

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_PROGRAMS
   can_clone_file
   fopen_unchanged
   fseek
+  local_header_mismatch
 )
 
 set(GETOPT_USERS

--- a/regress/local-header-mismatch.test
+++ b/regress/local-header-mismatch.test
@@ -1,0 +1,3 @@
+description default entry reads reject local/central header mismatches
+program local_header_mismatch
+return 0

--- a/regress/programs/local_header_mismatch.c
+++ b/regress/programs/local_header_mismatch.c
@@ -1,0 +1,289 @@
+/*
+  local_header_mismatch.c -- verify default reads reject local/central header mismatches
+  Copyright (C) 2026
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+*/
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "zip.h"
+
+#define ARCHIVE "local-header-mismatch.zip"
+
+#define CENTRAL_CRC_OFFSET 16
+#define CENTRAL_COMP_SIZE_OFFSET 20
+#define CENTRAL_UNCOMP_SIZE_OFFSET 24
+#define CENTRAL_LOCAL_HEADER_OFFSET 42
+
+static const zip_uint8_t central_magic[] = {0x50, 0x4b, 0x01, 0x02};
+static const zip_uint8_t local_magic[] = {0x50, 0x4b, 0x03, 0x04};
+
+static int add_stored_file(zip_t *za, const char *name, const zip_uint8_t *data, zip_uint64_t length);
+static int check_checkcons_rejects_archive(void);
+static int check_default_read_rejects_archive(void);
+static int create_confused_archive(void);
+static int find_nth_signature(const zip_uint8_t *data, size_t length, const zip_uint8_t *signature, unsigned int nth, size_t *offsetp);
+static int patch_central_directory(void);
+static zip_uint32_t read_le32(const zip_uint8_t *data);
+static void write_le32(zip_uint8_t *data, zip_uint32_t value);
+
+static int
+add_stored_file(zip_t *za, const char *name, const zip_uint8_t *data, zip_uint64_t length) {
+    zip_int64_t index;
+    zip_source_t *source;
+
+    if ((source = zip_source_buffer(za, data, length, 0)) == NULL) {
+        fprintf(stderr, "can't create source for '%s': %s\n", name, zip_strerror(za));
+        return -1;
+    }
+
+    if ((index = zip_file_add(za, name, source, 0)) < 0) {
+        fprintf(stderr, "can't add '%s': %s\n", name, zip_strerror(za));
+        zip_source_free(source);
+        return -1;
+    }
+
+    if (zip_set_file_compression(za, (zip_uint64_t)index, ZIP_CM_STORE, 0) < 0) {
+        fprintf(stderr, "can't force stored compression for '%s': %s\n", name, zip_strerror(za));
+        return -1;
+    }
+
+    return 0;
+}
+
+
+static int
+check_checkcons_rejects_archive(void) {
+    int err;
+    zip_t *za;
+
+    err = 0;
+    za = zip_open(ARCHIVE, ZIP_CHECKCONS, &err);
+    if (za != NULL) {
+        fprintf(stderr, "ZIP_CHECKCONS unexpectedly accepted crafted archive\n");
+        zip_close(za);
+        return -1;
+    }
+    if (err != ZIP_ER_INCONS) {
+        zip_error_t zip_error;
+
+        zip_error_init_with_code(&zip_error, err);
+        fprintf(stderr, "ZIP_CHECKCONS failed with %s instead of inconsistency\n", zip_error_strerror(&zip_error));
+        zip_error_fini(&zip_error);
+        return -1;
+    }
+
+    return 0;
+}
+
+
+static int
+check_default_read_rejects_archive(void) {
+    int err;
+    zip_error_t *zip_error;
+    zip_file_t *zf;
+    zip_t *za;
+
+    err = 0;
+    za = zip_open(ARCHIVE, 0, &err);
+    if (za == NULL) {
+        zip_error_t open_error;
+
+        zip_error_init_with_code(&open_error, err);
+        fprintf(stderr, "can't open crafted archive without ZIP_CHECKCONS: %s\n", zip_error_strerror(&open_error));
+        zip_error_fini(&open_error);
+        return -1;
+    }
+
+    zf = zip_fopen(za, "safe.txt", 0);
+    if (zf != NULL) {
+        char buffer[32];
+        zip_int64_t n;
+
+        n = zip_fread(zf, buffer, sizeof(buffer) - 1);
+        if (n < 0) {
+            fprintf(stderr, "zip_fopen unexpectedly succeeded and zip_fread then failed: %s\n", zip_file_strerror(zf));
+        }
+        else {
+            buffer[n] = '\0';
+            fprintf(stderr, "zip_fopen unexpectedly succeeded and returned '%s'\n", buffer);
+        }
+        zip_fclose(zf);
+        zip_close(za);
+        return -1;
+    }
+
+    zip_error = zip_get_error(za);
+    if (zip_error_code_zip(zip_error) != ZIP_ER_INCONS) {
+        fprintf(stderr, "zip_fopen failed with %s instead of inconsistency\n", zip_strerror(za));
+        zip_close(za);
+        return -1;
+    }
+
+    zip_close(za);
+    return 0;
+}
+
+
+static int
+create_confused_archive(void) {
+    static const zip_uint8_t evil_payload[] = "EVIL_PAYLOAD!!";
+    static const zip_uint8_t safe_payload[] = "SAFE";
+    int err;
+    zip_t *za;
+
+    err = 0;
+    za = zip_open(ARCHIVE, ZIP_CREATE | ZIP_TRUNCATE, &err);
+    if (za == NULL) {
+        zip_error_t zip_error;
+
+        zip_error_init_with_code(&zip_error, err);
+        fprintf(stderr, "can't create '%s': %s\n", ARCHIVE, zip_error_strerror(&zip_error));
+        zip_error_fini(&zip_error);
+        return -1;
+    }
+
+    if (add_stored_file(za, "safe.txt", safe_payload, sizeof(safe_payload) - 1) < 0
+        || add_stored_file(za, "evil.txt", evil_payload, sizeof(evil_payload) - 1) < 0) {
+        zip_discard(za);
+        return -1;
+    }
+
+    if (zip_close(za) < 0) {
+        fprintf(stderr, "can't finalize '%s': %s\n", ARCHIVE, zip_strerror(za));
+        zip_discard(za);
+        return -1;
+    }
+
+    return patch_central_directory();
+}
+
+
+static int
+find_nth_signature(const zip_uint8_t *data, size_t length, const zip_uint8_t *signature, unsigned int nth, size_t *offsetp) {
+    size_t i;
+    unsigned int seen;
+
+    seen = 0;
+    for (i = 0; i + 4 <= length; i++) {
+        if (memcmp(data + i, signature, 4) == 0) {
+            if (seen == nth) {
+                *offsetp = i;
+                return 0;
+            }
+            seen++;
+        }
+    }
+
+    return -1;
+}
+
+
+static int
+patch_central_directory(void) {
+    zip_uint8_t *data;
+    size_t evil_central_offset, evil_local_offset, safe_central_offset, safe_local_offset;
+    size_t length;
+    FILE *fp;
+
+    if ((fp = fopen(ARCHIVE, "rb")) == NULL) {
+        fprintf(stderr, "can't reopen '%s' for patching\n", ARCHIVE);
+        return -1;
+    }
+    if (fseek(fp, 0, SEEK_END) < 0) {
+        fprintf(stderr, "can't seek to end of '%s'\n", ARCHIVE);
+        fclose(fp);
+        return -1;
+    }
+    length = (size_t)ftell(fp);
+    rewind(fp);
+
+    if ((data = (zip_uint8_t *)malloc(length)) == NULL) {
+        fprintf(stderr, "malloc failed while patching '%s'\n", ARCHIVE);
+        fclose(fp);
+        return -1;
+    }
+    if (fread(data, 1, length, fp) != length) {
+        fprintf(stderr, "can't read '%s'\n", ARCHIVE);
+        free(data);
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+
+    if (find_nth_signature(data, length, local_magic, 0, &safe_local_offset) < 0
+        || find_nth_signature(data, length, local_magic, 1, &evil_local_offset) < 0
+        || find_nth_signature(data, length, central_magic, 0, &safe_central_offset) < 0
+        || find_nth_signature(data, length, central_magic, 1, &evil_central_offset) < 0) {
+        fprintf(stderr, "can't locate expected ZIP headers in '%s'\n", ARCHIVE);
+        free(data);
+        return -1;
+    }
+
+    if (read_le32(data + safe_central_offset + CENTRAL_LOCAL_HEADER_OFFSET) != (zip_uint32_t)safe_local_offset
+        || read_le32(data + evil_central_offset + CENTRAL_LOCAL_HEADER_OFFSET) != (zip_uint32_t)evil_local_offset) {
+        fprintf(stderr, "unexpected local header offsets while patching '%s'\n", ARCHIVE);
+        free(data);
+        return -1;
+    }
+
+    write_le32(data + safe_central_offset + CENTRAL_CRC_OFFSET, read_le32(data + evil_central_offset + CENTRAL_CRC_OFFSET));
+    write_le32(data + safe_central_offset + CENTRAL_COMP_SIZE_OFFSET, read_le32(data + evil_central_offset + CENTRAL_COMP_SIZE_OFFSET));
+    write_le32(data + safe_central_offset + CENTRAL_UNCOMP_SIZE_OFFSET, read_le32(data + evil_central_offset + CENTRAL_UNCOMP_SIZE_OFFSET));
+    write_le32(data + safe_central_offset + CENTRAL_LOCAL_HEADER_OFFSET, read_le32(data + evil_central_offset + CENTRAL_LOCAL_HEADER_OFFSET));
+
+    if ((fp = fopen(ARCHIVE, "wb")) == NULL) {
+        fprintf(stderr, "can't reopen '%s' for writing\n", ARCHIVE);
+        free(data);
+        return -1;
+    }
+    if (fwrite(data, 1, length, fp) != length) {
+        fprintf(stderr, "can't rewrite '%s'\n", ARCHIVE);
+        free(data);
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+    free(data);
+
+    return 0;
+}
+
+
+static zip_uint32_t
+read_le32(const zip_uint8_t *data) {
+    return (zip_uint32_t)data[0]
+           | ((zip_uint32_t)data[1] << 8)
+           | ((zip_uint32_t)data[2] << 16)
+           | ((zip_uint32_t)data[3] << 24);
+}
+
+
+static void
+write_le32(zip_uint8_t *data, zip_uint32_t value) {
+    data[0] = (zip_uint8_t)(value & 0xff);
+    data[1] = (zip_uint8_t)((value >> 8) & 0xff);
+    data[2] = (zip_uint8_t)((value >> 16) & 0xff);
+    data[3] = (zip_uint8_t)((value >> 24) & 0xff);
+}
+
+
+int
+main(void) {
+    if (create_confused_archive() < 0) {
+        return 1;
+    }
+    if (check_checkcons_rejects_archive() < 0) {
+        return 1;
+    }
+    if (check_default_read_rejects_archive() < 0) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This change rejects local/central header mismatches during ordinary reads and adds a regression that exercises a crafted archive with a forged local-header pointer.

The root cause is that `_zip_file_get_offset()` trusted the local header at the central-directory offset without verifying that the parsed local metadata still matched the central entry. `ZIP_CHECKCONS` already rejected this archive shape, but default reads could still follow a mismatched local header and open the wrong payload. This patch parses the local header, compares the relevant metadata against the central entry, and returns an inconsistency error when they diverge.

Impact:
- default reads now fail closed on forged local-header redirections
- behavior is aligned with `ZIP_CHECKCONS` for this inconsistency class
- the regression creates and patches a synthetic archive that previously opened the wrong file data

Validation:
- `cmake -S . -B build-pr -DNIHTEST=/usr/bin/true`
- `cmake --build build-pr --target local_header_mismatch -j4`
- `./build-pr/regress/local_header_mismatch`
