### PR TITLE
Report deferred read integrity errors on close

### DIFF
--- a/lib/zip_fclose.c
+++ b/lib/zip_fclose.c
@@ -36,6 +36,30 @@
 
 #include "zipint.h"
 
+static void
+check_for_pending_read_error(zip_file_t *zf) {
+    zip_stat_t st;
+    zip_int64_t position;
+    zip_int64_t n;
+    zip_uint8_t dummy;
+
+    zip_stat_init(&st);
+    if (zip_source_stat(zf->src, &st) < 0 || (st.valid & ZIP_STAT_SIZE) == 0) {
+        return;
+    }
+    if ((position = zip_source_tell(zf->src)) < 0 || (zip_uint64_t)position != st.size) {
+        return;
+    }
+
+    n = zip_source_read(zf->src, &dummy, 1);
+    if (n < 0) {
+        zip_error_set_from_source(&zf->error, zf->src);
+    }
+    else if (n > 0) {
+        zip_error_set(&zf->error, ZIP_ER_INCONS, MAKE_DETAIL_WITH_INDEX(ZIP_ER_DETAIL_INVALID_FILE_LENGTH, MAX_DETAIL_INDEX));
+    }
+}
+
 
 ZIP_EXTERN int zip_fclose(zip_file_t *zf) {
     int ret;
@@ -45,6 +69,9 @@ ZIP_EXTERN int zip_fclose(zip_file_t *zf) {
     }
 
     if (zf->src) {
+        if (zf->error.zip_err == 0) {
+            check_for_pending_read_error(zf);
+        }
         zip_source_free(zf->src);
     }
 

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -3,6 +3,7 @@ check_function_exists(getopt HAVE_GETOPT)
 set(TEST_PROGRAMS
   add_from_filep
   can_clone_file
+  exact_read_integrity
   fopen_unchanged
   fseek
 )

--- a/regress/exact-read-integrity.test
+++ b/regress/exact-read-integrity.test
@@ -1,0 +1,5 @@
+description exact-size reads report integrity errors on close
+program exact_read_integrity
+return 0
+file broken.zip broken.zip
+file hmac-error.zip hmac-error.zip

--- a/regress/programs/exact_read_integrity.c
+++ b/regress/programs/exact_read_integrity.c
@@ -1,0 +1,100 @@
+/*
+  exact_read_integrity.c -- verify close reports deferred integrity failures
+  Copyright (C) 2026
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+*/
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "zip.h"
+
+static int
+check_case(const char *archive, const char *password, const char *name, int expected_close_err) {
+    int err;
+    int close_err;
+    int fail;
+    char *buf;
+    zip_file_t *zf;
+    zip_int64_t n;
+    zip_stat_t st;
+    zip_t *za;
+
+    fail = 0;
+    err = 0;
+    buf = NULL;
+    za = zip_open(archive, 0, &err);
+    if (za == NULL) {
+        zip_error_t zip_error;
+
+        zip_error_init_with_code(&zip_error, err);
+        fprintf(stderr, "can't open '%s': %s\n", archive, zip_error_strerror(&zip_error));
+        zip_error_fini(&zip_error);
+        return 1;
+    }
+
+    if (password != NULL && zip_set_default_password(za, password) < 0) {
+        fprintf(stderr, "can't set password for '%s': %s\n", archive, zip_strerror(za));
+        zip_close(za);
+        return 1;
+    }
+
+    zip_stat_init(&st);
+    if (zip_stat(za, name, 0, &st) < 0) {
+        fprintf(stderr, "can't stat '%s' in '%s': %s\n", name, archive, zip_strerror(za));
+        zip_close(za);
+        return 1;
+    }
+
+    if ((zf = zip_fopen(za, name, 0)) == NULL) {
+        fprintf(stderr, "can't open '%s' in '%s': %s\n", name, archive, zip_strerror(za));
+        zip_close(za);
+        return 1;
+    }
+
+    if ((buf = (char *)malloc((size_t)st.size)) == NULL) {
+        fprintf(stderr, "malloc failed for '%s'\n", name);
+        zip_fclose(zf);
+        zip_close(za);
+        return 1;
+    }
+
+    n = zip_fread(zf, buf, st.size);
+    if (n != (zip_int64_t)st.size) {
+        if (n < 0) {
+            fprintf(stderr, "zip_fread unexpectedly failed for '%s' in '%s': %s\n", name, archive, zip_file_strerror(zf));
+        }
+        else {
+            fprintf(stderr, "zip_fread unexpectedly returned %lld instead of %llu for '%s' in '%s'\n", (long long)n, (unsigned long long)st.size, name, archive);
+        }
+        fail = 1;
+    }
+
+    close_err = zip_fclose(zf);
+    if (close_err != expected_close_err) {
+        fprintf(stderr, "zip_fclose returned %d instead of %d for '%s' in '%s'\n", close_err, expected_close_err, name, archive);
+        fail = 1;
+    }
+
+    free(buf);
+    zip_close(za);
+
+    return fail;
+}
+
+
+int
+main(void) {
+    int fail;
+
+    fail = 0;
+    fail += check_case("broken.zip", NULL, "storedok", 0);
+    fail += check_case("broken.zip", NULL, "storedcrcerror", ZIP_ER_CRC);
+    fail += check_case("broken.zip", NULL, "deflatecrcerror", ZIP_ER_CRC);
+    fail += check_case("hmac-error.zip", "1234", "test.txt", ZIP_ER_CRC);
+
+    return fail ? 1 : 0;
+}


### PR DESCRIPTION
This change makes `zip_fclose()` report deferred integrity failures when a caller reads exactly the advertised file size, and adds a regression that covers CRC and encrypted-HMAC failures.

The root cause is that integrity errors can remain pending until the underlying source is asked for one more byte at end-of-stream. If the caller stops after an exact-size `zip_fread()`, libzip currently frees the source without surfacing the deferred failure. This patch performs a final probe in `zip_fclose()` when no prior error is recorded and the source position matches the advertised size.

Impact:
- exact-size reads no longer mask deferred CRC/HMAC/length failures
- callers now see the same integrity result whether they over-read by one byte or stop at the reported size
- regressions cover stored, deflated, and encrypted cases

Validation:
- `cmake -S . -B build-pr -DNIHTEST=/usr/bin/true`
- `cmake --build build-pr --target exact_read_integrity -j4`
- `cd regress/data && ../../build-pr/regress/exact_read_integrity`
