### PR TITLE
Fix large-offset source seek arithmetic

### DIFF
--- a/lib/zip_source_seek.c
+++ b/lib/zip_source_seek.c
@@ -35,6 +35,29 @@
 #include "zipint.h"
 
 
+bool _zip_offset_add(zip_uint64_t offset, zip_int64_t delta, zip_uint64_t *result) {
+    if (delta >= 0) {
+        zip_uint64_t unsigned_delta = (zip_uint64_t)delta;
+
+        if (offset > ZIP_UINT64_MAX - unsigned_delta) {
+            return false;
+        }
+        *result = offset + unsigned_delta;
+    }
+    else {
+        /* Handle ZIP_INT64_MIN without overflowing signed arithmetic. */
+        zip_uint64_t unsigned_delta = (zip_uint64_t)(-(delta + 1)) + 1;
+
+        if (offset < unsigned_delta) {
+            return false;
+        }
+        *result = offset - unsigned_delta;
+    }
+
+    return true;
+}
+
+
 ZIP_EXTERN int zip_source_seek(zip_source_t *src, zip_int64_t offset, int whence) {
     zip_source_args_seek_t args;
 
@@ -59,7 +82,7 @@ ZIP_EXTERN int zip_source_seek(zip_source_t *src, zip_int64_t offset, int whence
 
 
 zip_int64_t zip_source_seek_compute_offset(zip_uint64_t offset, zip_uint64_t length, void *data, zip_uint64_t data_length, zip_error_t *error) {
-    zip_int64_t new_offset;
+    zip_uint64_t new_offset;
     zip_source_args_seek_t *args = ZIP_SOURCE_GET_ARGS(zip_source_args_seek_t, data, data_length, error);
 
     if (args == NULL) {
@@ -68,15 +91,25 @@ zip_int64_t zip_source_seek_compute_offset(zip_uint64_t offset, zip_uint64_t len
 
     switch (args->whence) {
     case SEEK_CUR:
-        new_offset = (zip_int64_t)offset + args->offset;
+        if (!_zip_offset_add(offset, args->offset, &new_offset)) {
+            zip_error_set(error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
         break;
 
     case SEEK_END:
-        new_offset = (zip_int64_t)length + args->offset;
+        if (!_zip_offset_add(length, args->offset, &new_offset)) {
+            zip_error_set(error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
         break;
 
     case SEEK_SET:
-        new_offset = args->offset;
+        if (args->offset < 0) {
+            zip_error_set(error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
+        new_offset = (zip_uint64_t)args->offset;
         break;
 
     default:
@@ -84,10 +117,10 @@ zip_int64_t zip_source_seek_compute_offset(zip_uint64_t offset, zip_uint64_t len
         return -1;
     }
 
-    if (new_offset < 0 || (zip_uint64_t)new_offset > length) {
+    if (new_offset > length || new_offset > ZIP_INT64_MAX) {
         zip_error_set(error, ZIP_ER_INVAL, 0);
         return -1;
     }
 
-    return new_offset;
+    return (zip_int64_t)new_offset;
 }

--- a/lib/zip_source_window.c
+++ b/lib/zip_source_window.c
@@ -274,22 +274,30 @@ static zip_int64_t window_read(zip_source_t *src, void *_ctx, void *data, zip_ui
                 return 0;
             }
             else {
-                if (args->whence == SEEK_CUR) {
-                    if (args->offset > 0 && (zip_int64_t)ctx->offset + args->offset < args->offset) {
+                zip_uint64_t relative_offset;
+
+                if (args->whence == SEEK_SET) {
+                    if (args->offset < 0) {
                         zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
                         return -1;
                     }
-                    args->offset += (zip_int64_t)ctx->offset;
+                    relative_offset = (zip_uint64_t)args->offset;
                 }
-                if (args->offset < 0) {
+                else if (!_zip_offset_add(ctx->offset - ctx->start, args->offset, &relative_offset)) {
                     zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
                     return -1;
                 }
-                if (zip_source_seek(src, args->offset, SEEK_SET) < 0) {
+
+                if (ZIP_CHECK_ADD_OVERFLOW(ctx->start, relative_offset) || ctx->start + relative_offset > ZIP_INT64_MAX) {
+                    zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
+                    return -1;
+                }
+
+                ctx->offset = ctx->start + relative_offset;
+                if (zip_source_seek(src, (zip_int64_t)ctx->offset, SEEK_SET) < 0) {
                     zip_error_set_from_source(&ctx->error, src);
                     return -1;
                 }
-                ctx->offset = (zip_uint64_t)args->offset;
                 return 0;
             }
         }

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -630,6 +630,7 @@ bool zip_realloc(void **memory, zip_uint64_t *alloced_elements, zip_uint64_t ele
 bool zip_secure_random(zip_uint8_t *buffer, zip_uint16_t length);
 zip_uint32_t zip_random_uint32(void);
 
+bool _zip_offset_add(zip_uint64_t offset, zip_int64_t delta, zip_uint64_t *result);
 int _zip_read(zip_source_t *src, zip_uint8_t *data, zip_uint64_t length, zip_error_t *error);
 int _zip_read_at_offset(zip_source_t *src, zip_uint64_t offset, unsigned char *b, size_t length, zip_error_t *error);
 zip_uint8_t *_zip_read_data(zip_buffer_t *buffer, zip_source_t *src, size_t length, bool nulp, zip_error_t *error);
@@ -648,6 +649,7 @@ zip_source_t *_zip_source_file_or_p(const char *, FILE *, zip_uint64_t, zip_int6
 bool _zip_source_had_error(zip_source_t *);
 void _zip_source_invalidate(zip_source_t *src);
 zip_source_t *_zip_source_new(zip_error_t *error);
+zip_int64_t zip_source_seek_compute_offset(zip_uint64_t offset, zip_uint64_t length, void *data, zip_uint64_t data_length, zip_error_t *error);
 int _zip_source_set_source_archive(zip_source_t *, zip_t *);
 zip_source_t *_zip_source_window_new(zip_source_t *src, zip_uint64_t start, zip_int64_t length, zip_stat_t *st, zip_uint64_t st_invalid, zip_file_attributes_t *attributes, zip_dostime_t *dostime, zip_t *source_archive, zip_uint64_t source_index, bool take_ownership, zip_error_t *error);
 

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_PROGRAMS
   can_clone_file
   fopen_unchanged
   fseek
+  source_seek
 )
 
 set(GETOPT_USERS

--- a/regress/programs/source_seek.c
+++ b/regress/programs/source_seek.c
@@ -1,0 +1,163 @@
+/*
+  source_seek.c -- regress source seek edge cases
+  Copyright (C) 2026 Dieter Baron and Thomas Klausner
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+  The authors can be contacted at <info@libzip.org>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+  3. The names of the authors may not be used to endorse or promote
+     products derived from this software without specific prior
+     written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+
+#include "zip.h"
+
+static int
+test_unknown_length_window(void) {
+    zip_error_t error;
+    zip_source_t *base, *window;
+    char data[] = "0123456789";
+    char c;
+
+    zip_error_init(&error);
+
+    if ((base = zip_source_buffer_create(data, sizeof(data) - 1, 0, &error)) == NULL) {
+        fprintf(stderr, "can't create buffer source: %s\n", zip_error_strerror(&error));
+        zip_error_fini(&error);
+        return -1;
+    }
+    if ((window = zip_source_window_create(base, 5, -1, &error)) == NULL) {
+        fprintf(stderr, "can't create window source: %s\n", zip_error_strerror(&error));
+        zip_source_free(base);
+        zip_error_fini(&error);
+        return -1;
+    }
+    zip_error_fini(&error);
+    zip_source_free(base);
+
+    if (zip_source_open(window) < 0) {
+        fprintf(stderr, "can't open window source\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_read(window, &c, 1) != 1 || c != '5') {
+        fprintf(stderr, "window source returned wrong initial byte\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_seek(window, 0, SEEK_SET) < 0) {
+        fprintf(stderr, "can't seek to beginning of window source\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_read(window, &c, 1) != 1 || c != '5') {
+        fprintf(stderr, "window source SEEK_SET ignored window start\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_seek(window, 2, SEEK_SET) < 0) {
+        fprintf(stderr, "can't seek forward inside window source\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_read(window, &c, 1) != 1 || c != '7') {
+        fprintf(stderr, "window source SEEK_SET used wrong offset\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_seek(window, -4, SEEK_CUR) == 0) {
+        fprintf(stderr, "window source allowed seek before window start\n");
+        zip_source_free(window);
+        return -1;
+    }
+    zip_source_free(window);
+
+    return 0;
+}
+
+
+static int
+test_large_fragment_source(void) {
+    zip_error_t error;
+    zip_source_t *source;
+    zip_buffer_fragment_t fragments[2];
+    zip_uint8_t a = 'a', b = 'b';
+
+    fragments[0].data = &a;
+    fragments[0].length = ZIP_INT64_MAX;
+    fragments[1].data = &b;
+    fragments[1].length = 10;
+
+    zip_error_init(&error);
+    if ((source = zip_source_buffer_fragment_create(fragments, 2, 0, &error)) == NULL) {
+        fprintf(stderr, "can't create fragment source: %s\n", zip_error_strerror(&error));
+        zip_error_fini(&error);
+        return -1;
+    }
+    zip_error_fini(&error);
+
+    if (zip_source_open(source) < 0) {
+        fprintf(stderr, "can't open fragment source\n");
+        zip_source_free(source);
+        return -1;
+    }
+    if (zip_source_seek(source, -10, SEEK_END) < 0) {
+        fprintf(stderr, "can't seek to representable offset near end of fragment source\n");
+        zip_source_free(source);
+        return -1;
+    }
+    if (zip_source_tell(source) != ZIP_INT64_MAX) {
+        fprintf(stderr, "fragment source reported wrong position after SEEK_END\n");
+        zip_source_free(source);
+        return -1;
+    }
+    if (zip_source_seek(source, -1, SEEK_END) == 0) {
+        fprintf(stderr, "fragment source allowed unrepresentable offset\n");
+        zip_source_free(source);
+        return -1;
+    }
+    zip_source_free(source);
+
+    return 0;
+}
+
+
+int
+main(int argc, char *argv[]) {
+    if (argc > 2) {
+        fprintf(stderr, "usage: %s [ignored]\n", argv[0]);
+        return 1;
+    }
+
+    if (test_unknown_length_window() < 0) {
+        return 1;
+    }
+    if (test_large_fragment_source() < 0) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/regress/source-seek.test
+++ b/regress/source-seek.test
@@ -1,0 +1,4 @@
+# test seek edge cases for sources and unknown-length windows
+program source_seek
+arguments ignored
+return 0


### PR DESCRIPTION
## Summary
- make source seek offset arithmetic overflow-safe for large logical offsets
- fix unknown-length window sources so `SEEK_SET` and `SEEK_CUR` stay relative to the window start
- add a regression program covering unknown-length window seeks and large fragment-backed sources

## Verification
- `cmake -S . -B build -DBUILD_REGRESS=ON -DBUILD_OSSFUZZ=OFF -DBUILD_DOC=OFF -DBUILD_EXAMPLES=OFF`
- `cmake --build build --target zip -j4`
- `cc -I$(pwd)/lib -I$(pwd)/build -L$(pwd)/build/lib -Wl,-rpath,$(pwd)/build/lib -o /tmp/source_seek regress/programs/source_seek.c -lzip`
- `/tmp/source_seek ignored`

## Notes
- `nihtest` is not available in this environment, so CMake disables the full regress target here.
