### PR TITLE
Add c++ guards to fuzzers

### DIFF
--- a/ossfuzz/zip_read_metadata_fuzzer.c
+++ b/ossfuzz/zip_read_metadata_fuzzer.c
@@ -49,6 +49,10 @@ static const zip_uint16_t PROBE_IDS[] = {
 };
 #define N_PROBE_IDS (sizeof(PROBE_IDS) / sizeof(PROBE_IDS[0]))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     zip_source_t *src;
     zip_error_t   error;
@@ -127,3 +131,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/ossfuzz/zip_write_roundtrip_fuzzer.c
+++ b/ossfuzz/zip_write_roundtrip_fuzzer.c
@@ -71,6 +71,10 @@ take(stream_t *s, size_t max, size_t *out_len) {
 
 static const char *PASSWORD = "fuzzpw";
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     zip_error_t error;
@@ -260,3 +264,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     zip_source_free(src); /* release keep reference */
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
libzip doesn't currently build in OSS-Fuzz: https://introspector.oss-fuzz.com/project-profile?project=libzip

I believe this PR should fix that.

Also concerns #539 and #543.