### PR TITLE
Fix source error handling across reopen

### DIFF
--- a/lib/zip_source_close.c
+++ b/lib/zip_source_close.c
@@ -56,13 +56,8 @@ int zip_source_close(zip_source_t *src) {
         }
     }
 
-    if (!_zip_source_had_error(src)) {
-        /* If the last read caused an error, get it. */
-        _zip_source_get_error(src);
-
-        if (ZIP_SOURCE_IS_LAYERED(src) && _zip_source_had_error(src->src)) {
-            zip_error_set_from_source(&src->error, src->src);
-        }
+    if (!_zip_source_had_error(src) && ZIP_SOURCE_IS_LAYERED(src) && _zip_source_had_error(src->src)) {
+        zip_error_set_from_source(&src->error, src->src);
     }
 
     return _zip_source_had_error(src) ? -1 : 0;

--- a/lib/zip_source_winzip_aes_decode.c
+++ b/lib/zip_source_winzip_aes_decode.c
@@ -163,6 +163,7 @@ static zip_int64_t winzip_aes_decrypt(zip_source_t *src, void *ud, void *data, z
         return ctx->current_position == ctx->data_length;
 
     case ZIP_SOURCE_OPEN:
+        zip_error_set(&ctx->error, ZIP_ER_OK, 0);
         if (decrypt_header(src, ctx) < 0) {
             return -1;
         }
@@ -202,8 +203,12 @@ static zip_int64_t winzip_aes_decrypt(zip_source_t *src, void *ud, void *data, z
             return zip_error_code_zip(&ctx->error) != ZIP_ER_OK ? -1 : 0;
         }
 
-    case ZIP_SOURCE_CLOSE:
-        return 0;
+    case ZIP_SOURCE_CLOSE: {
+        bool had_error = zip_error_code_zip(&ctx->error) != ZIP_ER_OK;
+        _zip_winzip_aes_free(ctx->aes_ctx);
+        ctx->aes_ctx = NULL;
+        return had_error ? -1 : 0;
+    }
 
     case ZIP_SOURCE_STAT: {
         zip_stat_t *st;

--- a/regress/programs/exact_read_integrity.c
+++ b/regress/programs/exact_read_integrity.c
@@ -9,8 +9,67 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "zip.h"
+
+struct nonseekable_context {
+    const char *data;
+    zip_uint64_t length;
+    zip_uint64_t offset;
+    zip_error_t error;
+};
+
+
+static zip_int64_t
+nonseekable_source(void *userdata, void *data, zip_uint64_t length, zip_source_cmd_t command) {
+    struct nonseekable_context *ctx = (struct nonseekable_context *)userdata;
+
+    switch (command) {
+    case ZIP_SOURCE_CLOSE:
+        return 0;
+
+    case ZIP_SOURCE_ERROR:
+        return zip_error_to_data(&ctx->error, data, length);
+
+    case ZIP_SOURCE_FREE:
+        return 0;
+
+    case ZIP_SOURCE_OPEN:
+        ctx->offset = 0;
+        return 0;
+
+    case ZIP_SOURCE_READ:
+        if (length > ctx->length - ctx->offset) {
+            length = ctx->length - ctx->offset;
+        }
+        memcpy(data, ctx->data + ctx->offset, (size_t)length);
+        ctx->offset += length;
+        return (zip_int64_t)length;
+
+    case ZIP_SOURCE_STAT: {
+        zip_stat_t *st;
+
+        if (length < sizeof(*st)) {
+            zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
+            return -1;
+        }
+        st = (zip_stat_t *)data;
+        zip_stat_init(st);
+        st->size = ctx->length;
+        st->valid = ZIP_STAT_SIZE;
+        return sizeof(*st);
+    }
+
+    case ZIP_SOURCE_SUPPORTS:
+        return ZIP_SOURCE_SUPPORTS_READABLE | ZIP_SOURCE_MAKE_COMMAND_BITMASK(ZIP_SOURCE_SUPPORTS_REOPEN);
+
+    default:
+        zip_error_set(&ctx->error, ZIP_ER_OPNOTSUPP, 0);
+        return -1;
+    }
+}
+
 
 static int
 check_case(const char *archive, const char *password, const char *name, int expected_close_err) {
@@ -86,6 +145,92 @@ check_case(const char *archive, const char *password, const char *name, int expe
 }
 
 
+static int
+check_nonseekable_reopen(void) {
+    static const char input[] = "abc";
+    char output[sizeof(input)] = {0};
+    struct nonseekable_context ctx;
+    zip_error_t error;
+    zip_source_t *source;
+
+    ctx.data = input;
+    ctx.length = sizeof(input) - 1;
+    ctx.offset = 0;
+    zip_error_init(&ctx.error);
+    zip_error_init(&error);
+    source = zip_source_function_create(nonseekable_source, &ctx, &error);
+    if (source == NULL) {
+        fprintf(stderr, "can't create non-seekable source: %s\n", zip_error_strerror(&error));
+        zip_error_fini(&ctx.error);
+        zip_error_fini(&error);
+        return 1;
+    }
+
+    if (zip_source_open(source) < 0 || zip_source_read(source, output, 1) != 1 || zip_source_at_eof(source) != 0 || zip_source_close(source) < 0) {
+        fprintf(stderr, "can't prime non-seekable source\n");
+        zip_source_free(source);
+        zip_error_fini(&ctx.error);
+        zip_error_fini(&error);
+        return 1;
+    }
+    if (zip_source_open(source) < 0 || zip_source_read(source, output, sizeof(input) - 1) != sizeof(input) - 1 || memcmp(input, output, sizeof(input) - 1) != 0) {
+        fprintf(stderr, "reopened non-seekable source returned wrong data\n");
+        zip_source_free(source);
+        zip_error_fini(&ctx.error);
+        zip_error_fini(&error);
+        return 1;
+    }
+
+    (void)zip_source_close(source);
+    zip_source_free(source);
+    zip_error_fini(&ctx.error);
+    zip_error_fini(&error);
+    return 0;
+}
+
+
+static int
+check_reopened_source(void) {
+    static const char input[] = "abc";
+    char output[sizeof(input)] = {0};
+    zip_error_t error;
+    zip_source_t *source;
+
+    zip_error_init(&error);
+    source = zip_source_buffer_create(input, sizeof(input) - 1, 0, &error);
+    if (source == NULL) {
+        fprintf(stderr, "can't create buffer source: %s\n", zip_error_strerror(&error));
+        zip_error_fini(&error);
+        return 1;
+    }
+
+    if (zip_source_open(source) < 0 || zip_source_seek(source, -1, SEEK_SET) == 0) {
+        fprintf(stderr, "can't trigger source error\n");
+        zip_source_free(source);
+        zip_error_fini(&error);
+        return 1;
+    }
+    (void)zip_source_close(source);
+
+    if (zip_source_open(source) < 0 || zip_source_read(source, output, sizeof(input) - 1) != sizeof(input) - 1 || memcmp(input, output, sizeof(input) - 1) != 0) {
+        fprintf(stderr, "can't read reopened source\n");
+        zip_source_free(source);
+        zip_error_fini(&error);
+        return 1;
+    }
+    if (zip_source_close(source) < 0) {
+        fprintf(stderr, "closing reopened source failed: %s\n", zip_error_strerror(zip_source_error(source)));
+        zip_source_free(source);
+        zip_error_fini(&error);
+        return 1;
+    }
+
+    zip_source_free(source);
+    zip_error_fini(&error);
+    return 0;
+}
+
+
 int
 main(void) {
     int fail;
@@ -95,6 +240,8 @@ main(void) {
     fail += check_case("broken.zip", NULL, "storedcrcerror", ZIP_ER_CRC);
     fail += check_case("broken.zip", NULL, "deflatecrcerror", ZIP_ER_CRC);
     fail += check_case("hmac-error.zip", "1234", "test.txt", ZIP_ER_CRC);
+    fail += check_nonseekable_reopen();
+    fail += check_reopened_source();
 
     return fail ? 1 : 0;
 }


### PR DESCRIPTION
Follow-up to #552 and bf51731.

This PR originally covered two reopen regressions. Upstream commit 4cd7310 has now adopted the lookahead reset from this PR; this refresh rebases on current `main` and keeps regression coverage for it.

The remaining functional changes are:

- `zip_source_close()` no longer queries `ZIP_SOURCE_ERROR` after a callback returned success. Callback failures are already captured when they return `-1`; querying after success can resurrect an error from an earlier open cycle.
- The WinZip AES source explicitly reports deferred integrity failures from `ZIP_SOURCE_CLOSE`, clears its private error on reopen, and releases its crypto context on close. These changes preserve HMAC error propagation after removing the unconditional error query and avoid leaking the prior context across a partial-read reopen.

Regression coverage includes the lookahead case fixed by 4cd7310 and the still-distinct stale-error case. On current unmodified `main` plus the regression test, the latter fails with `closing reopened source failed: Invalid argument`; this patch passes it.

Validation:

- `ctest --test-dir build -R "^exact-read-integrity\\.test$" --output-on-failure`: passed.
- `ctest --test-dir build --parallel 4 --output-on-failure`: 187/187 passed.
- The prior AppVeyor build passed all x64 and Win32 jobs. Its two ARM jobs failed before project configuration because the runner lacks the selected Windows ARM SDK; current upstream `main` build 1.0.1028 fails in the same jobs for the same reason.