### PR TITLE
Require Zip64 EF for 0xFFFFFFFF sentinels and check EF size overflow

### DIFF
--- a/lib/zip_dirent.c
+++ b/lib/zip_dirent.c
@@ -578,18 +578,26 @@ zip_int64_t _zip_dirent_read(zip_dirent_t *zde, zip_source_t *src, zip_buffer_t 
         zde->comment = utf8_string;
     }
 
-    /* Zip64 */
-
-    if (zde->uncomp_size == ZIP_UINT32_MAX || zde->comp_size == ZIP_UINT32_MAX || zde->offset == ZIP_UINT32_MAX) {
+    /* Zip64: APPNOTE requires a Zip64 EF whenever a field uses the 0xFFFFFFFF
+     * sentinel. Accepting the sentinel without an EF leaves fake 4GiB sizes and
+     * selects the wrong data-descriptor width. */
+    if (zde->uncomp_size == ZIP_UINT32_MAX || zde->comp_size == ZIP_UINT32_MAX ||
+        zde->offset == ZIP_UINT32_MAX) {
         zip_uint16_t got_len;
-        const zip_uint8_t *ef = _zip_ef_get_by_id(zde->extra_fields, &got_len, ZIP_EF_ZIP64, 0, local ? ZIP_EF_LOCAL : ZIP_EF_CENTRAL, error);
-        if (ef != NULL) {
-            if (!zip_dirent_process_ef_zip64(zde, ef, got_len, local, error)) {
-                if (!from_buffer) {
-                    _zip_buffer_free(buffer);
-                }
-                return -1;
+        const zip_uint8_t *ef = _zip_ef_get_by_id(zde->extra_fields, &got_len, ZIP_EF_ZIP64, 0,
+            local ? ZIP_EF_LOCAL : ZIP_EF_CENTRAL, error);
+        if (ef == NULL) {
+            zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_INVALID_ZIP64_EF);
+            if (!from_buffer) {
+                _zip_buffer_free(buffer);
             }
+            return -1;
+        }
+        if (!zip_dirent_process_ef_zip64(zde, ef, got_len, local, error)) {
+            if (!from_buffer) {
+                _zip_buffer_free(buffer);
+            }
+            return -1;
         }
         is_zip64 = true;
     }
@@ -1072,8 +1080,14 @@ int _zip_dirent_write(zip_t *za, zip_dirent_t *de, zip_flags_t flags) {
     _zip_buffer_put_16(buffer, _zip_string_length(de->filename));
     ef_total_size = _zip_ef_size(ef, ZIP_EF_BOTH);
     if (!ZIP_WANT_TORRENTZIP(za)) {
-        /* TODO: check for overflow */
-        ef_total_size += _zip_ef_size(de->extra_fields, flags);
+        zip_uint32_t add = _zip_ef_size(de->extra_fields, flags);
+        if (ef_total_size > ZIP_UINT32_MAX - add) {
+            zip_error_set(&za->error, ZIP_ER_EF_TOO_LARGE, 0);
+            _zip_buffer_free(buffer);
+            _zip_ef_free(ef);
+            return -1;
+        }
+        ef_total_size += add;
     }
     if (ef_total_size > ZIP_UINT16_MAX) {
         zip_error_set(&za->error, ZIP_ER_EF_TOO_LARGE, 0);

--- a/lib/zip_file_get_offset.c
+++ b/lib/zip_file_get_offset.c
@@ -47,13 +47,29 @@
 zip_uint64_t _zip_file_get_offset(const zip_t *za, zip_uint64_t idx, zip_error_t *error) {
     zip_uint64_t offset;
     zip_int32_t size;
+    zip_uint8_t magic[4];
+    zip_dirent_t *de;
 
     if (za->entry[idx].orig == NULL) {
         zip_error_set(error, ZIP_ER_INTERNAL, 0);
         return 0;
     }
 
-    offset = za->entry[idx].orig->offset;
+    de = za->entry[idx].orig;
+    offset = de->offset;
+
+    if (zip_source_seek(za->src, (zip_int64_t)offset, SEEK_SET) < 0) {
+        zip_error_set_from_source(error, za->src);
+        return 0;
+    }
+
+    if (_zip_read(za->src, magic, 4, error) < 0) {
+        return 0;
+    }
+    if (memcmp(magic, LOCAL_MAGIC, 4) != 0) {
+        zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_ENTRY_HEADER_MISMATCH);
+        return 0;
+    }
 
     if (zip_source_seek(za->src, (zip_int64_t)offset, SEEK_SET) < 0) {
         zip_error_set_from_source(error, za->src);
@@ -63,6 +79,28 @@ zip_uint64_t _zip_file_get_offset(const zip_t *za, zip_uint64_t idx, zip_error_t
     /* TODO: cache? */
     if ((size = _zip_dirent_size(za->src, ZIP_EF_LOCAL, error)) < 0) {
         return 0;
+    }
+
+    if (de->filename != NULL) {
+        zip_uint16_t local_name_len;
+        zip_uint8_t b[2];
+        zip_buffer_t *buffer;
+
+        /* After _zip_dirent_size the source sits past the local header.
+         * Re-seek to the filename length field (offset + 26). */
+        if (zip_source_seek(za->src, (zip_int64_t)offset + 26, SEEK_SET) < 0) {
+            zip_error_set_from_source(error, za->src);
+            return 0;
+        }
+        if ((buffer = _zip_buffer_new_from_source(za->src, 2, b, error)) == NULL) {
+            return 0;
+        }
+        local_name_len = _zip_buffer_get_16(buffer);
+        _zip_buffer_free(buffer);
+        if (local_name_len != _zip_string_length(de->filename)) {
+            zip_error_set(error, ZIP_ER_INCONS, ZIP_ER_DETAIL_ENTRY_HEADER_MISMATCH);
+            return 0;
+        }
     }
 
     if (offset + (zip_uint32_t)size > ZIP_INT64_MAX) {


### PR DESCRIPTION
## Summary
- Fail closed when a central/local header uses the `0xFFFFFFFF` Zip64 sentinel without a Zip64 extra field (APPNOTE requires the EF; without it sizes stay fake 4GiB and data-descriptor width is wrong).
- Check for unsigned overflow when summing extra-field lengths before applying the `ZIP_UINT16_MAX` cap (addresses the existing TODO in `_zip_dirent_write`).
- Validate `LOCAL_MAGIC` and that the local filename length matches the central directory before returning a data offset.

## Test plan
- [ ] Build + existing regress suite
- [ ] Archive with Zip64 sentinels but missing EF is rejected (`ZIP_ER_INCONS` / `INVALID_ZIP64_EF`)
- [ ] Valid Zip64 archives still open and extract
- [ ] Mismatched local vs central filename length is rejected on data access