### PR TITLE
Fix unknown-length window SEEK_END offset

### DIFF
--- a/lib/zip_source_window.c
+++ b/lib/zip_source_window.c
@@ -280,7 +280,7 @@ static zip_int64_t window_read(zip_source_t *src, void *_ctx, void *data, zip_ui
                 zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
                 return -1;
             }
-            ctx->offset = (zip_uint64_t)lower_offset - ctx->start;
+            ctx->offset = (zip_uint64_t)lower_offset;
             return 0;
         }
 

--- a/regress/programs/source_seek.c
+++ b/regress/programs/source_seek.c
@@ -93,6 +93,21 @@ test_unknown_length_window(void) {
         zip_source_free(window);
         return -1;
     }
+    if (zip_source_seek(window, -1, SEEK_END) < 0) {
+        fprintf(stderr, "can't seek relative to end of window source\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_tell(window) != 4) {
+        fprintf(stderr, "window source reported wrong position after SEEK_END\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_source_read(window, &c, 1) != 1 || c != '9') {
+        fprintf(stderr, "window source SEEK_END ignored window start\n");
+        zip_source_free(window);
+        return -1;
+    }
     zip_source_free(window);
 
     return 0;


### PR DESCRIPTION
## Summary

- keep unknown-length window offsets absolute after `SEEK_END`
- add regression coverage for tell/read behavior after an end-relative seek

## Problem

`struct window::offset` stores an absolute offset in the lower source. The
unknown-length `SEEK_END` path instead subtracted `ctx->start` before storing
the lower source's absolute position.

For a source containing `0123456789`, a window starting at byte 5 should expose
only `56789`. After seeking to `-1` from the end, the incorrect offset made
`zip_source_tell()` fail and the next read return `4`, a byte before the
window, instead of `9`.

The fix stores the absolute lower-source position, matching the other seek
paths and preserving the window boundary.

## Verification

- `ctest --test-dir build-full --output-on-failure -j8` (188/188 passed)
- focused regression failed before the fix and passed after it
