### PR TITLE
Fix extra-field cloning ownership leak

### DIFF
--- a/lib/zip_dirent.c
+++ b/lib/zip_dirent.c
@@ -217,7 +217,6 @@ zip_dirent_t *_zip_dirent_clone(const zip_dirent_t *sde) {
 
     if (sde) {
         (void)memcpy_s(tde, sizeof(*tde), sde, sizeof(*sde));
-        _zip_extra_fields_clone(&tde->extra_fields, NULL);
     }
     else {
         _zip_dirent_init(tde);

--- a/lib/zip_extra_field_api.c
+++ b/lib/zip_extra_field_api.c
@@ -253,6 +253,7 @@ ZIP_EXTERN int zip_file_extra_field_set(zip_t *za, zip_uint64_t idx, zip_uint16_
 
 int _zip_file_extra_field_prepare_for_change(zip_t *za, zip_uint64_t idx) {
     zip_entry_t *e;
+    zip_extra_fields_t extra_fields;
 
     if (idx >= za->nentry) {
         zip_error_set(&za->error, ZIP_ER_INVAL, 0);
@@ -276,6 +277,15 @@ int _zip_file_extra_field_prepare_for_change(zip_t *za, zip_uint64_t idx) {
             zip_error_set(&za->error, ZIP_ER_MEMORY, 0);
             return -1;
         }
+    }
+
+    if (e->orig) {
+        extra_fields = e->orig->extra_fields;
+        if (!_zip_extra_fields_clone(&extra_fields, &za->error)) {
+            _zip_extra_fields_fini(&extra_fields);
+            return -1;
+        }
+        e->changes->extra_fields = extra_fields;
     }
 
     e->changes->changed |= ZIP_DIRENT_EXTRA_FIELD;


### PR DESCRIPTION
## Summary

- keep unchanged extra-field lists shared by generic directory-entry clones
- deep-clone both lists only when the extra-field API prepares an entry for mutation
- restore the copy-on-write ownership expected by directory-entry cleanup

## Impact

Commit `cbad2ba` made `_zip_dirent_clone()` deep-copy every extra field, but
`_zip_dirent_finalize()` deliberately frees extra fields only when
`ZIP_DIRENT_EXTRA_FIELD` is marked changed. As a result, ordinary operations
such as renaming an entry leak the copied, archive-controlled extra fields when
the archive is discarded.

In a long-lived archive normalization or repackaging service, repeated hostile
archives can therefore grow process memory until exhaustion. The input does not
need to be malformed.

A local harness used a 1.0 MiB ZIP with 16 maximum-sized central extra fields,
then opened, renamed, and discarded all entries 100 times:

- current `main`: 107.8 MiB peak footprint
- no-extra-field control: 1.2 MiB peak footprint
- this patch: 3.8 MiB peak footprint

Apple's `leaks` tool also traced the leaked allocations directly through
`_zip_dirent_clone()` and `_zip_extra_fields_clone()`.

## Validation

- full ASan/UBSan regression suite: 189/189 passed
- 100-cycle focused harness: clean under ASan/UBSan after the fix
- `git diff --check`: clean
