### PR TITLE
Fix extra field setter return value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # 1.12 [Unreleased]
 
+* Fix return value of `zip_file_extra_field_set()`.
 * Keep order of local extra fields, even if an identical extra field is present in the central directory.
 * Add `zip_source_at_eof()` and `ZIP_SOURCE_AT_EOF`.
 * Consistently report CRC and decryption errors when reading exactly to end-of-file.

--- a/lib/zip_extra_field_api.c
+++ b/lib/zip_extra_field_api.c
@@ -247,7 +247,7 @@ ZIP_EXTERN int zip_file_extra_field_set(zip_t *za, zip_uint64_t idx, zip_uint16_
         return -1;
     }
 
-    return _zip_extra_fields_set(&za->entry[idx].changes->extra_fields, flags, ef_id, ef_idx, data, len, &za->error);
+    return _zip_extra_fields_set(&za->entry[idx].changes->extra_fields, flags, ef_id, ef_idx, data, len, &za->error) ? 0 : -1;
 }
 
 

--- a/regress/extra_set_invalid_index.test
+++ b/regress/extra_set_invalid_index.test
@@ -1,0 +1,7 @@
+# reject an invalid extra field index
+arguments encrypt.zip set_extra 0 2345 0 c data
+return 1
+file encrypt.zip encrypt.zip encrypt.zip
+stderr
+can't set extra field data for file at index '0', extra field id '2345', index '0': Invalid argument
+end-of-inline-data


### PR DESCRIPTION
The extra-field refactor changed `zip_file_extra_field_set()` from returning `0` directly to returning the boolean result of `_zip_extra_fields_set()`. This inverted the public API contract: successful calls returned `1` instead of `0`, while failures returned `0` instead of `-1`. In particular, an invalid extra-field index was reported as success.

Map the internal boolean to the documented public return values and add a regression test for the invalid-index path. This behavior is on current main only, so no released version is affected.

Verification:
- `ctest --test-dir build-asan --output-on-failure -j4`
- 191/191 tests passed with AddressSanitizer and UndefinedBehaviorSanitizer enabled.

Assisted-by: OpenAI Codex