### PR TITLE
Reject window stat past lower source end

### DIFF
--- a/lib/zip_source_window.c
+++ b/lib/zip_source_window.c
@@ -325,6 +325,10 @@ static zip_int64_t window_read(zip_source_t *src, void *_ctx, void *data, zip_ui
                 st->size = ctx->end - ctx->start;
             }
             else if (st->valid & ZIP_STAT_SIZE) {
+                if (st->size < ctx->start) {
+                    zip_error_set(&ctx->error, ZIP_ER_INVAL, 0);
+                    return -1;
+                }
                 st->size -= ctx->start;
             }
         }

--- a/regress/programs/source_seek.c
+++ b/regress/programs/source_seek.c
@@ -160,6 +160,46 @@ test_large_fragment_source(void) {
 }
 
 
+static int
+test_unknown_length_window_stat_past_end(void) {
+    zip_error_t error;
+    zip_source_t *base, *window;
+    zip_stat_t st;
+    char data = 'x';
+
+    zip_error_init(&error);
+
+    if ((base = zip_source_buffer_create(&data, 1, 0, &error)) == NULL) {
+        fprintf(stderr, "can't create buffer source: %s\n", zip_error_strerror(&error));
+        zip_error_fini(&error);
+        return -1;
+    }
+    if ((window = zip_source_window_create(base, 2, -1, &error)) == NULL) {
+        fprintf(stderr, "can't create window source: %s\n", zip_error_strerror(&error));
+        zip_source_free(base);
+        zip_error_fini(&error);
+        return -1;
+    }
+    zip_error_fini(&error);
+    zip_source_free(base);
+
+    zip_stat_init(&st);
+    if (zip_source_stat(window, &st) == 0) {
+        fprintf(stderr, "window source reported a size for a start past the source end\n");
+        zip_source_free(window);
+        return -1;
+    }
+    if (zip_error_code_zip(zip_source_error(window)) != ZIP_ER_INVAL) {
+        fprintf(stderr, "window source returned wrong error for a start past the source end\n");
+        zip_source_free(window);
+        return -1;
+    }
+    zip_source_free(window);
+
+    return 0;
+}
+
+
 int
 main(int argc, char *argv[]) {
     if (argc > 2) {
@@ -171,6 +211,9 @@ main(int argc, char *argv[]) {
         return 1;
     }
     if (test_large_fragment_source() < 0) {
+        return 1;
+    }
+    if (test_unknown_length_window_stat_past_end() < 0) {
         return 1;
     }
 


### PR DESCRIPTION
## Summary

- reject an unknown-length window whose start exceeds the lower source size during `zip_source_stat()`
- prevent the unsigned subtraction from reporting `ZIP_UINT64_MAX` (or another wrapped size)
- add a public-API regression covering the out-of-range start

Before this change, a one-byte buffer wrapped with `zip_source_window_create(base, 2, -1, ...)` reported a size of `18446744073709551615`. File-backed sources already reject the equivalent range with `ZIP_ER_INVAL`; the window source now does the same when its lower source exposes a size.

## Verification

- built the library with CMake
- compiled and ran `regress/programs/source_seek.c` directly
- repeated the focused regression under AddressSanitizer and UndefinedBehaviorSanitizer