### PR TITLE
Preserve explicit crypto buffer clearing across backends

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ environment:
 
 before_build:
   cmd: >-
-    py -m pip install nihtest
+    py -3.11 -m pip install nihtest
 
     mkdir build
 
@@ -86,7 +86,7 @@ test_script:
   cmd: >-
     set VERBOSE=yes
 
-    IF %RUN_TESTS%==yes ( ctest -C %CMAKE_CONFIG% --output-on-failure )
+    IF %RUN_TESTS%==yes ( ctest -C %CMAKE_CONFIG% --output-on-failure --no-tests=error )
 
 cache:
   - c:\vcpkg.cache -> vcpkg.json

--- a/config.h.in
+++ b/config.h.in
@@ -27,6 +27,8 @@
 #cmakedefine HAVE_CLONEFILE
 #cmakedefine HAVE_COMMONCRYPTO
 #cmakedefine HAVE_CRYPTO
+#cmakedefine HAVE_EXPLICIT_BZERO
+#cmakedefine HAVE_EXPLICIT_MEMSET
 #cmakedefine HAVE_FICLONERANGE
 #cmakedefine HAVE_FILENO
 #cmakedefine HAVE_FCHMOD

--- a/lib/zipint.h
+++ b/lib/zipint.h
@@ -523,14 +523,29 @@ typedef struct _zip_pkware_keys zip_pkware_keys_t;
 #define ZIP_WANT_TORRENTZIP(za) ((za)->ch_flags & ZIP_AFL_WANT_TORRENTZIP)
 
 
+#include <string.h>
+
 #ifdef HAVE_EXPLICIT_MEMSET
 #define _zip_crypto_clear(b, l) explicit_memset((b), 0, (l))
 #else
 #ifdef HAVE_EXPLICIT_BZERO
 #define _zip_crypto_clear(b, l) explicit_bzero((b), (l))
 #else
-#include <string.h>
-#define _zip_crypto_clear(b, l) memset((b), 0, (l))
+#ifdef _MSC_VER
+static __inline
+#else
+static inline
+#endif
+    void
+    _zip_crypto_clear(void *buffer, size_t length) {
+    volatile unsigned char *p = (volatile unsigned char *)buffer;
+
+    /* Keep the clearing stores observable even when the buffer is no longer used. */
+    while (length > 0) {
+        *p++ = 0;
+        length--;
+    }
+}
 #endif
 #endif
 

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -3,6 +3,7 @@ check_function_exists(getopt HAVE_GETOPT)
 set(TEST_PROGRAMS
   add_from_filep
   can_clone_file
+  crypto_clear
   exact_read_integrity
   fopen_unchanged
   fseek

--- a/regress/crypto_clear.test
+++ b/regress/crypto_clear.test
@@ -1,0 +1,3 @@
+description internal crypto clear zeroes only the requested range
+program crypto_clear
+return 0

--- a/regress/programs/crypto_clear.c
+++ b/regress/programs/crypto_clear.c
@@ -1,0 +1,56 @@
+/*
+  crypto_clear.c -- verify internal crypto buffer clearing
+  SPDX-License-Identifier: BSD-3-Clause
+
+  This file is part of libzip, a library to manipulate ZIP archives.
+*/
+
+#include "config.h"
+
+#include <stdio.h>
+
+#include "zipint.h"
+
+
+static int check_range(void) {
+    unsigned char buffer[] = {0xa5, 0x11, 0x22, 0x33, 0x44, 0x5a};
+    size_t i;
+
+    _zip_crypto_clear(buffer + 1, 4);
+
+    if (buffer[0] != 0xa5 || buffer[5] != 0x5a) {
+        fprintf(stderr, "crypto clear modified a guard byte\n");
+        return 1;
+    }
+    for (i = 1; i < 5; i++) {
+        if (buffer[i] != 0) {
+            fprintf(stderr, "crypto clear did not clear byte %zu\n", i);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+static int check_zero_length(void) {
+    unsigned char buffer[] = {0xa5, 0x11, 0x22, 0x33, 0x44, 0x5a};
+    static const unsigned char expected[] = {0xa5, 0x11, 0x22, 0x33, 0x44, 0x5a};
+    size_t i;
+
+    _zip_crypto_clear(buffer + 2, 0);
+
+    for (i = 0; i < sizeof(buffer); i++) {
+        if (buffer[i] != expected[i]) {
+            fprintf(stderr, "zero-length crypto clear modified byte %zu\n", i);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+int main(void) {
+    return check_range() || check_zero_length();
+}


### PR DESCRIPTION
## Summary

The build already probes for `explicit_memset` and `explicit_bzero`, but their results were missing from `config.h.in`. Propagate those results so the existing `_zip_crypto_clear` backend selection can use the available API.

For systems without either API, use volatile-qualified byte stores instead of ordinary `memset`. Keep `string.h` available independently of the selected backend, and use the `__inline` spelling for MSVC's default C mode. Existing call sites and the public API are unchanged.

Add `crypto_clear.test` for clearing an exact range, preserving adjacent guard bytes, and doing nothing for a zero-length range.

Also install nihtest with the Python 3.11 launcher matching AppVeyor's existing PATH, and fail the test-enabled jobs if CTest discovers no tests. The first Windows CI run compiled successfully but silently disabled regressions because unqualified `py` installed nihtest under Python 3.14.

## Validation

- Linux GCC 15.2 static-library builds with OpenSSL enabled, both native `explicit_bzero` and forced fallback.
- The new test passed through CMake/CTest and nihtest 1.11.1 in both configurations with `-O3 -flto -DNDEBUG`.
- Focused direct test builds with `-Wall -Wextra -Werror` passed in the preceding local validation.
- A separate GCC `-O3` assembly check retains all 16 clearing stores to an otherwise unused local buffer in the fallback.
- Windows Visual Studio 2019 x64 and x86 both executed and passed `crypto_clear.test` after the Python launcher correction.
- The CI configuration parses with only the two intended command changes. An empty CTest control returns success by default and failure with `--no-tests=error`.
- clang-format 19 and diff whitespace checks pass.

### Windows CI follow-up

[AppVeyor build 1.0.1075](https://ci.appveyor.com/project/nih-at/libzip/builds/54671467), for PR head `bea92fc25b3f2a371b1ac2ee8c53431e1fcc49ec`:

- x64 Windows: 191 registered tests, zero failures and five skips.
- x86 Windows: 191 registered tests, two failures and five skips. `crypto_clear.test` passed; the failures are `set_compression_store_to_xz.test` and `set_compression_xz_to_store.test`.
- ARM Windows and ARM UWP fail during toolchain setup, before libzip compilation, with `MSB8037` for Windows SDK `10.0.26100.0` Desktop C++ ARM Apps. The preceding build of this PR has the same setup failure; it is not an unmodified upstream baseline.

The x86 job uses liblzma 5.8.1. [XZ 5.8.2 release notes](https://github.com/tukaani-project/xz/blob/master/NEWS) describe a workaround for a compiler bug in 32-bit x86 CLMUL CRC builds with older MSVC. This is a possible explanation, not a confirmed cause of these failures; no corrected-dependency Windows run has verified it. No failing tests have been disabled.

This does not establish a passing full CI matrix or validate the `explicit_memset` backend. The change strengthens the existing clearing primitive; it does not guarantee erasure of every possible copy of sensitive data.

Implementation and review were AI-assisted.
